### PR TITLE
Record current Xianting-native certification in docs authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ The current `0.8.0` release-candidate source is being certified on **GitHub-host
 | --- | --- |
 | Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
 | Tests / coverage | 747 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
-| Release-source commit / SHA-256 | pending fresh Xianting-native certification |
-| Real-paper discovery | 15/15 historical imported measurement; re-verified during fresh certification |
-| Environment planning | 3/3 historical imported measurement; re-verified during fresh certification |
-| ReproBench | 1 success / 1 partial / 0 failures historical imported; re-verified during fresh certification |
-| Evidence commit | pending fresh Xianting-native certification |
+| Release-source commit | `84fcc6f24610d13124fc204055166b2b069c8297` |
+| Release-source SHA-256 | `ef02b937193882f658a35d90da5a3dd60c212923c906ec4f7f1333b3dbee9ad2` |
+| Validation run | GitHub-hosted `VeriRepro validation` run `33276158764` |
+| Real-paper discovery | 15/15 (found, top-1, evidence anchored) |
+| Environment planning | 3/3 bounded repository plans |
+| ReproBench | 1 success / 1 partial / 0 failures |
+| Evidence commit | `027fe3c` (evidence-only promotion, sole parent certified source) |
 | Certification environment | exact committed dependency snapshot; resolved on GitHub-hosted `ubuntu-latest` |
 
 All CI and validation runs execute on GitHub-hosted ephemeral runners; logs are safe by design and are retained as public quality evidence. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -20,12 +20,12 @@ These identifiers do **not** match the current Xianting `main`. They are histori
 
 ## Current Xianting-native certification
 
-- Certified source: **pending** (fresh certification is produced after the public CI/release control plane is stable)
-- Release-source SHA-256: **pending**
-- Validation run: **pending**
-- Evidence commit: **pending**
+- Certified source: `84fcc6f24610d13124fc204055166b2b069c8297`
+- Release-source SHA-256: `ef02b937193882f658a35d90da5a3dd60c212923c906ec4f7f1333b3dbee9ad2`
+- Validation run: GitHub-hosted `VeriRepro validation` run `33276158764`
+- Evidence commit: `027fe3c`
 
-Until a fresh certification run completes, do not cite `32523314161`, `16044bec…`, or `e25cacde…` as current certification.
+Discovery 15/15, planning 3/3, ReproBench 1 success / 1 partial / 0 failures — all produced on GitHub-hosted `ubuntu-latest` at the exact certified source. The historical/imported identifiers above are superseded by this certification.
 
 ## Scientific limits
 

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -41,8 +41,8 @@ Status: **engineering-ready, not yet released.** The stable GitHub Release/PyPI 
 
 ## Evidence
 
-- [ ] pending: fresh Xianting-native certification (15-paper discovery, 3-repository planning, 2-case ReproBench) on GitHub-hosted validation
-- [x] historical/imported evidence is labelled historical only; not cited as current certification
+- [x] fresh Xianting-native certification completed on GitHub-hosted validation (run 33276158764, source 84fcc6f, fingerprint ef02b937…): discovery 15/15, planning 3/3, ReproBench 1 success / 1 partial / 0 failures
+- [x] historical/imported evidence is labelled historical only; current Xianting-native certification (run 33276158764) is the authority
 - [x] historical evidence for the older measured source only; current Xianting-native certification replaces it
 - [x] `docs/EVIDENCE.md` distinguishes historical from current evidence and records scientific limits
 


### PR DESCRIPTION
Update README, evidence policy, and release checklist to the fresh GitHub-hosted certification (run 33276158764, source 84fcc6f, fingerprint ef02b937). Historical/imported evidence stays labelled historical only.