### PR TITLE
docs: align public quality record with current certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The current `0.8.0` release-candidate source is being certified on **GitHub-host
 | Gate | Current measured result |
 | --- | --- |
 | Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
-| Tests / coverage | 747 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
+| Tests / coverage | 765 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
 | Release-source commit | `84fcc6f24610d13124fc204055166b2b069c8297` |
 | Release-source SHA-256 | `ef02b937193882f658a35d90da5a3dd60c212923c906ec4f7f1333b3dbee9ad2` |
 | Validation run | GitHub-hosted `VeriRepro validation` run `33276158764` |
@@ -246,7 +246,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before sending a change. For reproductio
 - General figure comparison is visual/pixel-based, not semantic plot understanding.
 - Automatic PDF Figure/Table crop-to-output matching is incomplete.
 - Environment reconstruction cannot make unavailable or underspecified upstream dependencies reproducible.
-- NVIDIA/CUDA hardware execution is not yet release-certified on a matching NVIDIA-capable trusted runner.
+- NVIDIA/CUDA hardware execution is not currently part of the public GitHub-hosted release-certification matrix.
 - Repository checkout does not currently have a hard transfer/working-tree byte quota.
 - Persistent experiment output has no portable hard filesystem quota; `--output-backend ephemeral` is available for less-trusted writers.
 - Dependency/image builds interact with the Docker daemon before the final non-root research-runtime boundary; hostile builds require stronger isolation.

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -48,7 +48,7 @@ Status: **engineering-ready, not yet released.** The stable GitHub Release/PyPI 
 
 ## Final quality target
 
-- [x] 747 tests; statement 86.4%; branch 79.9%
+- [x] 765 tests; statement 86.4%; branch 79.9%
 - [x] build / Twine / clean-wheel install PASS
 - [x] native history scan PASS; Gitleaks/TruffleHog to be re-run at final audit
 - [x] public launch surface PASS (`scripts/launch_surface_check.py`)


### PR DESCRIPTION
## Summary

- Align the current public test-count record with authoritative CI/validation output.

## Verification

- 765 tests passed
- statement coverage 86.4%
- branch coverage 79.9%
- release-source fingerprint unchanged
- no runtime/source/evidence changes

## Scope

- documentation only
- no release
- no tag
- no PyPI publication