### PR TITLE
Harden public trust and release contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality-py311:
     name: Quality (Python 3.11)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -74,6 +79,7 @@ jobs:
   compatibility-py312:
     name: Compatibility (Python 3.12)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -95,6 +101,7 @@ jobs:
   compatibility-py313:
     name: Compatibility (Python 3.13)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Test, build, and verify distributions
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -18,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
@@ -36,7 +37,7 @@ jobs:
             echo "Release tag ${GITHUB_REF_NAME} does not match pyproject version v${VERSION}" >&2
             exit 2
           }
-      - name: Require annotated signed tag on canonical main history
+      - name: Require cryptographically signed annotated tag on canonical main history
         run: |
           set -euo pipefail
           git fetch --force origin main
@@ -44,11 +45,10 @@ jobs:
             echo 'Stable publication requires a pre-created annotated tag.' >&2
             exit 2
           }
-          tag_payload="$(git cat-file tag "$GITHUB_REF_NAME")"
-          printf '%s\n' "$tag_payload" | grep -Eq -- '-----BEGIN (PGP|SSH) SIGNATURE-----' || {
-            echo 'Stable publication requires a cryptographically signed tag object.' >&2
-            exit 2
-          }
+          python scripts/verify_release_tag.py \
+            --tag "$GITHUB_REF_NAME" \
+            --allowed-signers .github/release-signers \
+            --expected-principal XiantingWu
           TAG_COMMIT="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
           HEAD_COMMIT="$(git rev-parse HEAD)"
           test "$TAG_COMMIT" = "$HEAD_COMMIT" || {
@@ -109,6 +109,7 @@ jobs:
     needs: build
     if: ${{ github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pypi
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable user-facing changes are recorded here. Internal CI incidents and one-off
 
 ## 0.8.0 — hardened runtime, verification, and release engineering
 
+0.4–0.7 were pre-public development milestones; 0.8.0 is the first planned stable public package publication.
+
 - add lock-aware environment realization for uv, Poetry, conda-lock, and Pipenv while reporting unlocked solve paths as potentially drift-prone;
 - add explicit GPU double authorization: repository request plus independent operator `--allow-gpu`; CUDA hints never grant devices;
 - add checksum-bound, concurrency-hardened host dataset caching with sanitized provenance and fail-safe lock contention;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,19 +70,21 @@ python scripts/launch_surface_check.py
 
 ### External and fork pull requests
 
-VeriRepro intentionally does **not** run contributor-controlled pull-request code automatically. The repository has no ordinary `pull_request` or `pull_request_target` execution workflow. This avoids sending untrusted fork code either to persistent maintainer hardware or to a hosted CI service that the project does not rely on for release certification.
+External/fork pull requests run public GitHub-hosted PR CI on ephemeral runners with `contents: read`, no repository secrets, no self-hosted execution, and no `pull_request_target`. Ordinary PR CI is quality/compatibility CI; validation is not PR-triggered and PR success is not release certification.
 
-The contribution path is:
+The contribution and certification path is:
 
-1. contributor opens a PR and provides local test evidence;
-2. maintainer reviews the diff, workflow changes, dependency changes, and trust-boundary impact without executing the fork branch on persistent infrastructure;
-3. the GitHub-hosted CI and validation workflows certify the merged `main` state;
-4. accepted changes are merged through the protected maintainer flow first; the public GitHub-hosted validation workflow then certifies only an exact SHA reachable from canonical `main` and publishes sanitized evidence artifacts;
-5. every release-facing source change receives fresh source-bound discovery/planning/ReproBench/certification-environment evidence from the GitHub-hosted validation workflow before release.
+1. contributor opens a PR;
+2. GitHub-hosted PR CI runs Python 3.11 quality plus Python 3.12 and 3.13 compatibility checks;
+3. PR CI remains read-only, secret-free, GitHub-hosted, and non-certifying;
+4. the maintainer reviews code, dependencies, workflows, and trust-boundary expansion;
+5. the PR merges through protected `main`;
+6. release-relevant `main` changes receive a fresh GitHub-hosted validation run;
+7. fresh sanitized evidence is promoted through an explicit evidence-only PR.
 
-Do not ask maintainers to execute fork PR code on self-hosted or persistent hardware. If stronger adversarial contribution testing becomes necessary, it must use genuinely disposable GitHub-hosted isolation.
+If stronger adversarial contribution testing becomes necessary, it must use genuinely disposable GitHub-hosted isolation.
 
-Real-paper and credentialed smoke workflows remain separate and maintainer-dispatched on GitHub-hosted runners. Their generated result files are transient and are not uploaded as GitHub Actions artifacts. Contributors do not need access to maintainer runners or credentials for ordinary pull requests.
+Credentialed model integrations are outside ordinary fork PR CI. If a future credentialed smoke is added, it must be manual, GitHub-hosted, environment-protected, and isolated from `pull_request` events. Its generated result files must remain transient rather than becoming ordinary PR artifacts.
 
 The release-only PyPI Trusted Publishing workflow is not a contribution CI lane. It is triggered only by a published GitHub Release and keeps OIDC publication authority isolated from source validation.
 

--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ PASS / FAIL / PARTIAL + evidence bundle
 
 ## Measured release evidence
 
-The current `0.8.0` release-candidate source is being certified on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. Evidence recorded in `benchmarks/` from an earlier development line is historical/imported and is replaced by fresh Xianting-native certification (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
+The `0.8.0` release-candidate source is certified on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The previously recorded certification below is historical and is superseded by this P1 hardening until fresh Xianting-native certification is promoted (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
 
 | Gate | Current measured result |
 | --- | --- |
 | Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
 | Tests / coverage | 765 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
-| Release-source commit | `84fcc6f24610d13124fc204055166b2b069c8297` |
-| Release-source SHA-256 | `ef02b937193882f658a35d90da5a3dd60c212923c906ec4f7f1333b3dbee9ad2` |
-| Validation run | GitHub-hosted `VeriRepro validation` run `33276158764` |
+| Historical release-source commit | `84fcc6f24610d13124fc204055166b2b069c8297` |
+| Historical release-source SHA-256 | `ef02b937193882f658a35d90da5a3dd60c212923c906ec4f7f1333b3dbee9ad2` |
+| Historical validation run | GitHub-hosted `VeriRepro validation` run `33276158764` |
 | Real-paper discovery | 15/15 (found, top-1, evidence anchored) |
 | Environment planning | 3/3 bounded repository plans |
 | ReproBench | 1 success / 1 partial / 0 failures |
-| Evidence commit | `027fe3c` (evidence-only promotion, sole parent certified source) |
+| Historical evidence commit | `027fe3c` (evidence-only promotion, sole parent certified source) |
 | Certification environment | exact committed dependency snapshot; resolved on GitHub-hosted `ubuntu-latest` |
 
 All CI and validation runs execute on GitHub-hosted ephemeral runners; logs are safe by design and are retained as public quality evidence. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.
@@ -235,9 +235,9 @@ python scripts/release_check.py
 python scripts/launch_surface_check.py
 ```
 
-External/fork pull requests run on **GitHub-hosted ephemeral runners** with read-only permissions and no repository secrets. VeriRepro never executes contributor-controlled code on maintainer-owned infrastructure. The exact canonical `main` SHA is certified through the public GitHub-hosted `VeriRepro validation` workflow, which publishes only sanitized evidence artifacts.
+External/fork pull requests receive **GitHub-hosted PR CI** on ephemeral runners with read-only permissions and no repository secrets. PR CI is quality/compatibility CI; manual GitHub-hosted validation certifies only the exact canonical `main` SHA. Validation publishes only sanitized evidence artifacts, which are promoted through an explicit evidence-only PR.
 
-GitHub-hosted CI is the sole automated quality/validation lane. The release-only exception is PyPI Trusted Publishing/OIDC delivery in `publish.yml`.
+GitHub-hosted CI is the sole automated quality/validation lane. PyPI Trusted Publishing/OIDC delivery in `publish.yml` is a separate release-only delivery boundary.
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before sending a change. For reproduction help, use [SUPPORT.md](SUPPORT.md). Security-sensitive findings belong in GitHub's private Security advisory flow, not a public issue.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ Release evidence is deliberately bounded. It demonstrates only the tested discov
 - [ ] add a rootless, VM-backed, or equivalently isolated dependency/image build backend;
 - [ ] add a hard repository-transfer/checkout byte budget rather than relying only on shallow clone and downstream limits;
 - [ ] continue reducing host-side parsing/build attack surface for intentionally adversarial inputs;
-- [ ] add genuinely disposable Linux compatibility execution if contributor demand justifies automatic fork testing.
+- [ ] broaden adversarial PR CI resource-boundary tests.
 
 ### Better scientific evidence
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,19 +45,19 @@ The non-root/read-only runtime applies to the final research-code container. It 
 
 ## Public pull requests and CI isolation
 
-External/fork pull requests run only on **GitHub-hosted ephemeral runners** with read-only repository permissions and no repository secrets. VeriRepro never executes contributor-controlled source on maintainer-owned or persistent infrastructure, and no workflow may use `pull_request_target` for contributor execution.
+External/fork pull requests run only on **GitHub-hosted ephemeral PR CI** with `contents: read`, read-only behavior, and no repository secrets. No self-hosted execution and no `pull_request_target` may be used for contributor code.
 
-Do not execute external fork pull-request code on persistent self-hosted runners. All CI and validation jobs run on GitHub-hosted ephemeral runners only. Approval of a GitHub pull request is not itself a sandbox boundary. Maintainers must first review the diff, dependency/workflow changes, and authority expansion; accepted changes are merged through the protected maintainer flow, then the exact canonical `main` SHA is certified by the public GitHub-hosted `VeriRepro validation` workflow.
+`ci.yml` is the canonical public PR/main CI. `validation.yml` is manual GitHub-hosted certification of an exact canonical `main` SHA. `publish.yml` is GitHub-hosted OIDC delivery and is isolated from PR execution. PR CI success is quality evidence only; it is not release certification.
 
-A source-changing contribution is expected to differ from the previous release evidence. Final `--require-release-evidence` and `release_source_check.py` gates are maintainer release responsibilities: the GitHub-hosted validation lane produces fresh source-bound discovery/planning/ReproBench evidence from canonical `main`, with raw run logs kept transient and only sanitized evidence artifacts published.
+Maintainers review code, dependency/workflow changes, and authority expansion before merge. After merge, the manual validation workflow produces fresh source-bound discovery/planning/ReproBench evidence from canonical `main`, with raw run logs kept transient and only sanitized evidence artifacts published.
 
-Networked or credentialed integration workflows remain separate. Real-paper discovery and LiteLLM smoke tests are maintainer-dispatched on trusted integration infrastructure; external fork pull requests cannot invoke those workflows.
+Credentialed model integrations are outside ordinary fork PR CI. If a future credentialed smoke is added, it must be manual, GitHub-hosted, environment-protected, and isolated from `pull_request` events.
 
 Maintainer release validation keeps promoted evidence deliberately narrow: release-promotable discovery/planning JSON plus the ReproBench manifest, summary, and sanitized result JSON. Temporary PDFs, cloned third-party repositories, experiment workspaces, provider prompts/responses, credentials, and raw logs remain transient state and are not redistributed as release evidence.
 
 The PyPI publish workflow is a separate release-delivery boundary, not a contribution CI lane. It is triggered only by a published GitHub Release, uses the protected `pypi` environment and OIDC, and never receives pull-request events. The official PyPA publishing action is kept isolated from source validation authority.
 
-The release-tree checker and regression tests enforce the review-only contribution boundary, reject `pull_request_target`, reject reintroduction of the legacy hosted `ci.yml`, and prevent non-publish workflows from silently depending on GitHub-hosted runners.
+The release-tree checker and regression tests enforce the GitHub-hosted PR CI contract, reject `pull_request_target`, reject private runner labels, require explicit workflow resource bounds, and require the publish workflow to verify a release tag cryptographically.
 
 ## Important residual risks
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -40,7 +40,7 @@ See `SECURITY.md` for scope and the documented residual risks.
 
 ## Contribution questions
 
-Before proposing code, read `CONTRIBUTING.md`. External pull requests are review-only and do not automatically execute contributor-controlled code. Maintainers promote reviewed changes into the trusted `integration/**` lane when they are ready for execution on project infrastructure.
+Before proposing code, read `CONTRIBUTING.md`. External PRs receive GitHub-hosted secret-free CI, but they do not receive certification authority. Only merged canonical `main` may be certified by the manual GitHub-hosted validation workflow. Sanitized evidence is promoted through an explicit evidence-only PR.
 
 ## What support cannot promise
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,18 +122,25 @@ See `SCHEMAS.md`, `REPROBENCH.md`, and `TRUST_MODEL.md` for compatibility and tr
 - `common.py`: shared file inventory, safe path handling, command-gate helpers.
 - `package_surface.py`: distribution metadata, version alignment across namespaces, canonical repository URLs.
 - `security_surface.py`: trust-boundary declarations in `SECURITY.md`, private advisory routing, historical-incubator rejection.
-- `workflow_surface.py`: workflow trigger/runner-label contracts, review-only fork isolation, action pinning, publish-workflow safety.
+- `workflow_surface.py`: workflow trigger/runner-label contracts, GitHub-hosted fork-PR isolation, resource bounds, action pinning, publish-workflow safety.
+- `public_contract_surface.py`: current public contribution, certification, evidence-promotion, and delivery language.
 - `benchmark_surface.py`: smoke corpus and release-evidence structure checks.
 
 Every check appends human-readable errors and fails closed: any error fails the entire release check, and missing files are failures rather than skips. The layers are exercised directly by `tests/test_release_check_layers.py`.
 
 ## Release evidence lifecycle
 
-1. A maintainer cuts a read-only `validation/**` branch from the exact hardening SHA intended for certification; the branch is never modified after validation starts.
-2. The trusted GitHub-hosted `VeriRepro validation` workflow measures coverage, executes discovery/environment-planning/ReproBench gates, and stamps all measurements with the exact source SHA (`SOURCE_SHA`) via `scripts/stamp_release_measurement.py`.
-3. Evidence is sanitized (no host paths, credentials, prompts, or raw workspaces), hashed (`evidence.sha256`), and written back by a separate minimal job that executes no project code.
-4. `scripts/release_source_check.py` re-verifies that the certified source tree matches the fingerprint recorded in the evidence; `python scripts/release_check.py --require-release-evidence` enforces presence and structure at publish time.
-5. If runtime code, release scripts, or workflow policy change after certification, existing evidence is stale and must be regenerated from a new exact-head validation branch.
+1. Freeze a candidate canonical `main` SHA.
+2. Dispatch `VeriRepro validation` against that exact canonical source identity.
+3. Validation runs deterministic quality, discovery, planning, ReproBench, and environment checks on a GitHub-hosted runner.
+4. The workflow uploads only the sanitized evidence artifact; it does not modify a branch.
+5. The maintainer verifies source SHA, run ID, fingerprint, and evidence purity.
+6. Create an evidence branch from the certified source.
+7. Commit only version-matched benchmark evidence.
+8. Review and merge an explicit evidence-only PR.
+9. `release_source_check.py` revalidates source/evidence identity at publication time.
+
+If runtime code, release scripts, or workflow policy change after certification, existing evidence is stale and must be regenerated from a new exact canonical `main` SHA.
 
 ## Package and integration boundaries
 
@@ -141,4 +148,4 @@ The standalone package exposes the `verirepro` namespace and compatibility `repr
 
 Cross-project benchmark or agent integration uses versioned JSON, CLI/process boundaries, report schemas, or published packages instead of hidden relative imports.
 
-External/fork pull requests run only on GitHub-hosted ephemeral runners with read-only permissions and no secrets. Maintainers review the diff and merge through the protected `main` flow; the exact canonical `main` SHA is then certified by the public GitHub-hosted `VeriRepro validation` workflow. Final trusted benchmark evidence and source-fingerprint checks remain release gates and are enforced again before publication.
+External/fork pull requests use GitHub-hosted fork-PR isolation only: read-only, secret-free, no self-hosted runners, and no `pull_request_target`. Maintainers review the diff and merge through the protected `main` flow; the exact canonical `main` SHA is then certified by the public GitHub-hosted `VeriRepro validation` workflow. Final trusted benchmark evidence and source-fingerprint checks remain release gates and are enforced again before publication.

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -18,14 +18,18 @@ The benchmark files under `benchmarks/` currently contain measurements imported 
 
 These identifiers do **not** match the current Xianting `main`. They are historical provenance records only and are superseded by fresh Xianting-native certification when it is produced.
 
-## Current Xianting-native certification
+## Previous Xianting-native certification (historical)
 
 - Certified source: `84fcc6f24610d13124fc204055166b2b069c8297`
 - Release-source SHA-256: `ef02b937193882f658a35d90da5a3dd60c212923c906ec4f7f1333b3dbee9ad2`
 - Validation run: GitHub-hosted `VeriRepro validation` run `33276158764`
 - Evidence commit: `027fe3c`
 
-Discovery 15/15, planning 3/3, ReproBench 1 success / 1 partial / 0 failures — all produced on GitHub-hosted `ubuntu-latest` at the exact certified source. The historical/imported identifiers above are superseded by this certification.
+Discovery 15/15, planning 3/3, ReproBench 1 success / 1 partial / 0 failures — all produced on GitHub-hosted `ubuntu-latest` at the previous exact certified source. This certification is superseded by the P1 hardening source and is retained only as historical provenance.
+
+## Current Xianting-native certification
+
+Fresh exact-main validation and explicit evidence-only promotion are pending for the P1 hardening source. Until that lifecycle completes, no earlier run or fingerprint is current authority.
 
 ## Scientific limits
 

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,14 +1,14 @@
 # Public Release Checklist (0.8.0)
 
-Status: **engineering-ready, not yet released.** The stable GitHub Release/PyPI publication is intentionally the final launch step and requires a separate explicit authorization.
+Status: **P1 hardening candidate, not yet released.** The stable GitHub Release/PyPI publication requires separate explicit authorization.
 
 ## Runner architecture
 
 - [x] every executable workflow job runs on a GitHub-hosted runner (`ubuntu-latest`); zero jobs use `runs-on: self-hosted`
 - [x] zero workflow references private runner labels, runner groups, or private manager infrastructure
 - [x] public CI history is retained as quality evidence; no raw self-hosted logs exist by construction
-- [x] `certification/public-manager-policy.json` is absent; the public repository does not depend on any private certification lane
-- [ ] pending: confirm the fork live smoke executes on GitHub-hosted runners (see `test_public_ci_contract` / live smoke)
+- [x] self-hosted execution authority is none
+- [ ] live fork smoke: static contract PASS; live behavioral smoke is not yet verified
 
 ## CI
 
@@ -16,44 +16,50 @@ Status: **engineering-ready, not yet released.** The stable GitHub Release/PyPI 
 - [x] pull-request CI is secret-free; no `secrets.*` in ordinary CI
 - [x] all third-party Actions pinned to 40-character commit SHAs
 - [x] no `pull_request_target` contributor execution
-- [x] CPython 3.11/3.12/3.13 compatibility lane on GitHub-hosted runners
-- [x] coverage floors: statement >= 85%, branch >= 75% (measured 86.4% / 79.9% on 3.11)
+- [x] CPython 3.11/3.12/3.13 compatibility lanes run on GitHub-hosted runners
+- [x] explicit timeouts bound all CI jobs
+- [x] workflow-level concurrency cancels stale same-PR/branch CI
+- [x] coverage floors: statement >= 85%, branch >= 75%
 - [x] ruff, ruff format, mypy, history scan, release/launch policy gates in CI
 
-## Validation
+## Validation and evidence
 
-- [x] `validation.yml` is `workflow_dispatch`-only, GitHub-hosted, `contents: read`, no automatic evidence writeback
-- [x] validation produces sanitized evidence artifact (discovery / planning / ReproBench / certification environment / source fingerprint)
-- [x] evidence promotion is an explicit evidence-only PR reviewed by the maintainer
+- [x] `validation.yml` is `workflow_dispatch`-only, GitHub-hosted, `contents: read`, and has no branch mutation
+- [x] validation produces a sanitized evidence artifact (discovery / planning / ReproBench / certification environment / source fingerprint)
+- [x] evidence lifecycle is exact canonical main -> sanitized artifact -> maintainer verification -> explicit evidence-only PR
+- [x] no automatic evidence writeback
 
 ## Publish
 
 - [x] `publish.yml` is GitHub-hosted, release-only, protected `pypi` Environment, `id-token: write`, PyPI Trusted Publishing/OIDC
+- [x] publish uses release tag checkout rather than mutable `target_commitish`
+- [x] annotated tag, tag/version equality, dereferenced tag/checkout equality, and main ancestry are required
+- [x] cryptographic tag verification uses `git verify-tag` with a repository-pinned public SSH allowed-signers policy
 - [x] no long-lived PyPI token; publish refuses pre-release events
-- [x] publish re-runs release/launch/history/source gates before building
+- [x] publish re-runs release/launch/history/source/evidence gates before building
+- [ ] release signer policy public key is not yet provisioned; no stable tag may be created before it is provisioned
 
 ## Governance / security
 
-- [x] `main` protected: block force-push and deletion; require CI status checks and conversation resolution
+- [ ] main PR rule, strict required checks, and conversation resolution are active in the final ruleset
 - [x] private vulnerability reporting enabled; SECURITY.md route points to the canonical advisory flow
-- [x] issue forms (bug report, feature request, reproduction help) and dependabot configured
+- [x] issue forms (bug report, feature request, reproduction help) and Dependabot configured
 - [x] CODEOWNERS assigns XiantingWu as owner for release-sensitive paths
 
 ## Evidence
 
-- [x] fresh Xianting-native certification completed on GitHub-hosted validation (run 33276158764, source 84fcc6f, fingerprint ef02b937…): discovery 15/15, planning 3/3, ReproBench 1 success / 1 partial / 0 failures
-- [x] historical/imported evidence is labelled historical only; current Xianting-native certification (run 33276158764) is the authority
-- [x] historical evidence for the older measured source only; current Xianting-native certification replaces it
+- [ ] fresh certification on exact merged main is pending after P1 hardening
+- [ ] fresh evidence is pending after the exact merged-main certification run
+- [x] previous source/fingerprint/run are labelled historical after release-relevant hardening
 - [x] `docs/EVIDENCE.md` distinguishes historical from current evidence and records scientific limits
 
 ## Final quality target
 
-- [x] 765 tests; statement 86.4%; branch 79.9%
-- [x] build / Twine / clean-wheel install PASS
-- [x] native history scan PASS; Gitleaks/TruffleHog to be re-run at final audit
-- [x] public launch surface PASS (`scripts/launch_surface_check.py`)
-- [x] anonymous clone + quick start PASS (re-verified at final audit)
-- [x] full reachable Git history contains zero private runner / host identity metadata
+- [ ] fresh test count and coverage recorded after hardening
+- [ ] build / Twine / clean-wheel install PASS recorded after hardening
+- [ ] native history scan, Gitleaks, and TruffleHog PASS recorded at final audit
+- [ ] public launch surface, anonymous clone, and quick start PASS re-verified at final audit
+- [ ] full reachable Git history contains zero private runner / host identity metadata
 
 ## Deferred (explicit authorization required)
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -52,15 +52,15 @@ The release candidate is not ready if any command fails. Coverage must be measur
 
 ## Contribution trust promotion
 
-External/fork PRs are review-only. The normal trust promotion path is:
+External/fork PRs run public GitHub-hosted CI. The PR lane establishes contribution quality only; release certification occurs only after accepted source is merged to canonical `main` and validated by VeriRepro validation.
 
-1. review the PR diff without executing contributor-controlled code on persistent infrastructure;
-2. inspect dependency, workflow, network, filesystem, credential, and execution-authority changes;
+The normal trust promotion path is:
+
+1. run read-only, secret-free PR CI on GitHub-hosted runners;
+2. review code, dependency, workflow, network, filesystem, credential, and execution-authority changes;
 3. merge accepted changes through the protected maintainer flow;
 4. certify only an exact SHA reachable from canonical `main` on the GitHub-hosted validation workflow;
-5. produce fresh exact-source release evidence and promote only the sanitized `benchmarks/` evidence surface.
-
-If adversarial fork execution is ever needed, use genuinely disposable GitHub-hosted isolation rather than maintainer-owned infrastructure.
+5. verify the sanitized artifact and promote it through an explicit evidence-only PR.
 
 ## Repository controls
 
@@ -104,11 +104,13 @@ For version `X.Y.Z`:
 4. Run the GitHub-hosted `VeriRepro validation` workflow at that same source identity.
 5. Promote only the validation run's sanitized discovery/planning/ReproBench evidence; do not hand-author release evidence.
 6. Re-run `release_check.py --require-release-evidence` and `release_source_check.py` and verify the source fingerprint matches.
-7. Create and push a signed **annotated** tag named exactly `vX.Y.Z` from a commit reachable from canonical `main`; `publish.yml` rejects lightweight/unsigned-looking tag objects and non-main-line tag commits.
+7. Create and push a cryptographically signed **annotated** tag named exactly `vX.Y.Z` from a commit reachable from canonical `main`; `publish.yml` verifies it with the repository-pinned public SSH signer policy and rejects unsigned or unauthorized tags.
 8. Create a **non-prerelease** GitHub Release for that tag when publishing to stable PyPI.
 9. Approve the protected `pypi` deployment only after the release candidate and distributions have already been reviewed.
 
-The publish workflow refuses a release whose tag does not equal `v` plus the version in `pyproject.toml`, requires full Git history, an annotated tag object containing a PGP/SSH signature block, exact checkout/tag agreement, and reachability from canonical `main`; it then rechecks history/launch/release/source gates before building distributions and will not publish the PyPI job for a GitHub prerelease.
+The publish workflow checks out the release tag, refuses a tag that does not equal `v` plus the version in `pyproject.toml`, requires full Git history, an annotated tag object, cryptographic SSH verification against `.github/release-signers`, exact checkout/tag agreement, and reachability from canonical `main`; it then rechecks history/launch/release/source gates before building distributions and will not publish the PyPI job for a GitHub prerelease. The signer policy must be provisioned with public key material before a stable release tag is created.
+
+`.github/release-signers` is an OpenSSH allowed-signers policy containing public key lines such as `XiantingWu ssh-ed25519 AAAA...`. It must contain no private key, secret, or transport credential. The exact approved public signer and principal must be reviewed before the first stable tag.
 
 ## Evidence promotion
 
@@ -124,7 +126,7 @@ benchmarks/reprobench-results-0.8.0/
     <task-id>.json
 ```
 
-The validation workflow stages only sanitized evidence and hands it to a separate writeback job. Paper PDFs, cloned repositories, Docker contexts, workspaces, prompts/responses, credentials, and raw logs remain transient.
+The validation workflow stages and uploads only sanitized evidence. It does not modify a branch. Paper PDFs, cloned repositories, Docker contexts, workspaces, prompts/responses, credentials, and raw logs remain transient.
 
 The ReproBench manifest records the trusted Actions run id, workflow name, exact tested source SHA, and deterministic `source_tree_sha256`. Benchmark suite/task bytes are bound separately by SHA-256. Documentation and promoted evidence files are intentionally excluded from the source fingerprint.
 

--- a/docs/TRUST_MODEL.md
+++ b/docs/TRUST_MODEL.md
@@ -182,7 +182,28 @@ Repository planning distinguishes `planned`, `unsupported`, `infrastructure_erro
 
 For each release, front-half measurements and ReproBench evidence must be produced from the release-relevant source bytes for that version. Stable benchmark inputs do not prove stable algorithm behavior after source changes.
 
-The release-source fingerprint covers package/runtime Python, `pyproject.toml`, measurement/promotion policy, the ReproBench seed runner, public launch policy, layered release policy, trusted Quality/validation/smoke workflows, and the release-only publish workflow. Changing release-relevant bytes after evidence production invalidates the evidence and requires a fresh trusted measurement run. Documentation and promoted evidence files are intentionally outside that source fingerprint.
+The release-source fingerprint covers package/runtime Python, `pyproject.toml`, measurement/promotion policy, the ReproBench seed runner, public launch policy, layered release policy, public CI/validation workflows, and the release-only publish workflow. Changing release-relevant bytes after evidence production invalidates the evidence and requires a fresh trusted measurement run. Documentation and promoted evidence files are intentionally outside that source fingerprint.
+
+The public authority model is intentionally narrow:
+
+- GitHub-hosted CI is the sole automated CI authority;
+- GitHub-hosted validation is the certification authority;
+- GitHub-hosted publish is the delivery authority;
+- Self-hosted execution authority: none.
+
+PR CI success != release certification. Certification requires manual validation of the exact canonical `main` SHA.
+
+The evidence lifecycle is:
+
+1. freeze a candidate canonical `main` SHA;
+2. dispatch validation against that exact source identity;
+3. run deterministic quality, discovery, planning, ReproBench, and environment checks;
+4. upload only the sanitized evidence artifact;
+5. verify source SHA, run ID, fingerprint, and evidence purity;
+6. create an evidence branch from the certified source;
+7. commit only version-matched benchmark evidence;
+8. review and merge an explicit evidence-only PR;
+9. revalidate source/evidence identity at publication time.
 
 ## Secrets
 
@@ -192,17 +213,17 @@ VeriRepro supports `VERIREPRO_LITELLM_*`, standard `LITELLM_*`, and legacy `REPR
 
 For gated/private Hugging Face files, `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` is used only for the initial Hugging Face request host. If the request redirects to another host, sensitive authorization headers are stripped before following the redirect.
 
-## Public pull requests and maintainer integrations
+## Public pull requests and credentialed integrations
 
-External/fork pull requests run only on **GitHub-hosted ephemeral runners** with read-only repository permissions and no secrets. VeriRepro does not run `pull_request_target` workflows that execute contributor-controlled code, and no workflow may use self-hosted runners, private runner labels, or runner groups.
+External/fork pull requests run only on **GitHub-hosted ephemeral PR CI** with read-only permissions, no secrets, no self-hosted runners, and no `pull_request_target` execution. Fork PR code cannot grant certification or delivery authority.
 
-Accepted changes are merged through the protected `main` flow after maintainer review of the diff, dependency/workflow changes, and authority expansion. The public GitHub-hosted `VeriRepro validation` workflow then certifies the exact canonical `main` SHA. If the change becomes release-relevant, final release evidence is regenerated from that exact source identity.
+Accepted changes are merged through the protected `main` flow after maintainer review of the diff, dependency/workflow changes, and authority expansion. The public GitHub-hosted `VeriRepro validation` workflow then certifies the exact canonical `main` SHA. If the change becomes release-relevant, final release evidence is regenerated from that exact source identity and promoted through an explicit evidence-only PR.
 
-The project deliberately does not depend on GitHub-hosted CI for source correctness or launch readiness. Hosted runner availability, quota, or billing status therefore cannot turn a passing exact-head self-hosted certification into a code failure.
+Credentialed model integrations are outside ordinary fork PR CI. If a future credentialed smoke is added, it must be manual, GitHub-hosted, environment-protected, and isolated from `pull_request` events.
 
-The one hosted-runner exception is release delivery through `.github/workflows/publish.yml`: PyPA's official Trusted Publishing action is Linux-container based. That workflow is release-only, has no pull-request trigger, uses a protected `pypi` environment plus OIDC, and is not the authority that decides whether source is correct. All source/evidence gates must already pass before a stable release reaches the publishing boundary.
+The release-only delivery boundary is `.github/workflows/publish.yml`: PyPA's official Trusted Publishing action is Linux-container based. That workflow is release-only, has no pull-request trigger, uses a protected `pypi` environment plus OIDC, and delivers only after source/evidence gates pass.
 
-Networked or credentialed real-paper/LiteLLM integration smoke remains separate and maintainer-dispatched. Self-hosted or credentialed runners must never execute arbitrary external fork pull-request code.
+No self-hosted or credentialed runner may execute arbitrary external fork pull-request code.
 
 Trusted release evidence is deliberately narrow: promoted discovery/planning JSON and the ReproBench manifest/summary/result JSON. Paper PDFs, cloned repositories, Docker contexts, workspaces, prompts/responses, credentials, and raw logs remain transient state rather than public release evidence.
 

--- a/scripts/launch_surface_check.py
+++ b/scripts/launch_surface_check.py
@@ -120,7 +120,10 @@ def check_launch_surface(root: Path = ROOT) -> list[str]:
 
     release_checklist = public_identity["docs/PUBLIC_RELEASE_CHECKLIST.md"]
     if release_checklist:
-        if "historical evidence for the older measured source only" not in release_checklist:
+        if (
+            "previous source/fingerprint/run are labelled historical after release-relevant hardening"
+            not in release_checklist
+        ):
             errors.append("release checklist must distinguish historical from current 0.8 evidence")
 
     publish_path = root / ".github/workflows/publish.yml"

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -13,6 +13,7 @@ if __package__:
         check_required_files,
         load_pyproject,
     )
+    from .release_checks.public_contract_surface import check_public_contract_surface
     from .release_checks.security_surface import check_security_surface
     from .release_checks.workflow_surface import check_workflow_surface
 else:
@@ -24,6 +25,7 @@ else:
         check_required_files,
         load_pyproject,
     )
+    from release_checks.public_contract_surface import check_public_contract_surface
     from release_checks.security_surface import check_security_surface
     from release_checks.workflow_surface import check_workflow_surface
 
@@ -53,6 +55,7 @@ def check_release_tree(
 
     version = check_package_surface(root, pyproject, errors)
     check_security_surface(root, errors)
+    check_public_contract_surface(root, errors)
     check_certification_surface(root, errors)
     check_smoke_corpus(root, version=version, errors=errors)
     if require_release_evidence:

--- a/scripts/release_checks/public_contract_surface.py
+++ b/scripts/release_checks/public_contract_surface.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PUBLIC_CONTRACT_FILES = (
+    "README.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "SUPPORT.md",
+    "ROADMAP.md",
+    "docs/TRUST_MODEL.md",
+    "docs/ARCHITECTURE.md",
+    "docs/PUBLISHING.md",
+    "docs/PUBLIC_RELEASE_CHECKLIST.md",
+)
+
+_REQUIRED_FRAGMENTS: dict[str, tuple[str, ...]] = {
+    "README.md": (
+        "GitHub-hosted PR CI",
+        "manual GitHub-hosted validation",
+        "explicit evidence-only PR",
+    ),
+    "CONTRIBUTING.md": (
+        "GitHub-hosted PR CI",
+        "ordinary PR CI is quality/compatibility CI",
+        "validation is not PR-triggered",
+        "explicit evidence-only PR",
+    ),
+    "SECURITY.md": (
+        "GitHub-hosted ephemeral PR CI",
+        "read-only",
+        "no repository secrets",
+        "no self-hosted",
+        "no pull_request_target",
+        "ci.yml is the canonical public PR/main CI",
+        "validation.yml is manual GitHub-hosted certification",
+        "publish.yml is GitHub-hosted OIDC delivery",
+        "Credentialed model integrations are outside ordinary fork PR CI",
+    ),
+    "SUPPORT.md": (
+        "GitHub-hosted secret-free CI",
+        "do not receive certification authority",
+        "manual GitHub-hosted validation workflow",
+    ),
+    "ROADMAP.md": (
+        "external/fork pull requests run only on GitHub-hosted ephemeral runners",
+        "broaden adversarial PR CI resource-boundary tests",
+    ),
+    "docs/TRUST_MODEL.md": (
+        "GitHub-hosted CI is the sole automated CI authority",
+        "GitHub-hosted validation is the certification authority",
+        "GitHub-hosted publish is the delivery authority",
+        "Self-hosted execution authority: none",
+        "PR CI success != release certification",
+        "explicit evidence-only PR",
+    ),
+    "docs/ARCHITECTURE.md": (
+        "GitHub-hosted fork-PR isolation",
+        "secret-free",
+        "no self-hosted",
+        "no pull_request_target",
+        "explicit evidence-only PR",
+    ),
+    "docs/PUBLISHING.md": (
+        "External/fork PRs run public GitHub-hosted CI",
+        "explicit evidence-only PR",
+        "release tag",
+        "cryptographic",
+        "GitHub-hosted validation",
+    ),
+    "docs/PUBLIC_RELEASE_CHECKLIST.md": (
+        "timeouts",
+        "concurrency",
+        "release tag checkout",
+        "cryptographic tag verification",
+        "main PR rule",
+        "strict required checks",
+        "conversation resolution",
+        "fresh certification",
+        "fresh evidence",
+    ),
+}
+
+_FORBIDDEN_FRAGMENTS = (
+    "external/fork pull requests are review-only",
+    "external pull requests are review-only",
+    "no ordinary pull_request workflow",
+    "the repository has no ordinary pull_request",
+    "trusted integration/** lane",
+    "exact-head self-hosted certification",
+    "self-hosted certification authority",
+    "the one hosted-runner exception",
+    "the project deliberately does not depend on GitHub-hosted CI",
+    "does not depend on GitHub-hosted CI",
+    "separate writeback job",
+    "separate minimal writeback job",
+    "automatic writeback job",
+    "legacy hosted ci.yml",
+    "review-only contribution boundary",
+    "trusted integration infrastructure",
+)
+
+
+def _normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text.replace("`", "").casefold()).strip()
+
+
+def check_public_contract_surface(root: Path, errors: list[str]) -> None:
+    """Fail closed when public docs disagree with the current release architecture."""
+
+    root = Path(root).resolve()
+    documents: dict[str, str] = {}
+    for relative in PUBLIC_CONTRACT_FILES:
+        path = root / relative
+        if path.is_symlink() or not path.is_file():
+            errors.append(f"missing safe public contract document: {relative}")
+            continue
+        try:
+            documents[relative] = _normalized(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"could not read public contract document {relative}: {exc}")
+
+    for relative, fragments in _REQUIRED_FRAGMENTS.items():
+        text = documents.get(relative, "")
+        for fragment in fragments:
+            if _normalized(fragment) not in text:
+                errors.append(f"{relative} is missing current public contract: {fragment!r}")
+
+    for relative, text in documents.items():
+        for fragment in _FORBIDDEN_FRAGMENTS:
+            if _normalized(fragment) in text:
+                errors.append(f"{relative} contains retired public contract: {fragment!r}")

--- a/scripts/release_checks/security_surface.py
+++ b/scripts/release_checks/security_surface.py
@@ -6,7 +6,7 @@ from pathlib import Path
 CANONICAL_REPOSITORY = "https://github.com/XiantingWu/VeriRepro"
 SECURITY_ADVISORY = f"{CANONICAL_REPOSITORY}/security/advisories/new"
 FORK_EXECUTION_BOUNDARY = (
-    "Do not execute external fork pull-request code on persistent self-hosted runners"
+    "No self-hosted execution and no `pull_request_target` may be used for contributor code"
 )
 
 

--- a/scripts/release_checks/workflow_surface.py
+++ b/scripts/release_checks/workflow_surface.py
@@ -36,6 +36,7 @@ def check_workflow_surface(root: Path, errors: list[str]) -> None:
         _check_credentials(text, label=label, errors=errors)
         _check_action_pins(text, label=label, errors=errors)
         _check_permissions(text, label=label, errors=errors)
+        _check_resource_bounds(text, label=label, errors=errors)
 
     _check_publish_workflow(root, errors)
 
@@ -92,6 +93,38 @@ def _check_permissions(text: str, *, label: str, errors: list[str]) -> None:
         errors.append(f"only the publish workflow may request OIDC id-token: write: {label}")
 
 
+def _check_resource_bounds(text: str, *, label: str, errors: list[str]) -> None:
+    """Require an explicit timeout for every public workflow job and CI cancellation."""
+
+    runner_count = len(workflow_runs_on_lines(text))
+    timeout_count = text.count("timeout-minutes:")
+    if runner_count and timeout_count != runner_count:
+        errors.append(
+            f"every public workflow job must have an explicit timeout: {label} "
+            f"({timeout_count} timeouts for {runner_count} jobs)"
+        )
+
+    if label == ".github/workflows/ci.yml":
+        required = (
+            "concurrency:",
+            "group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+            "cancel-in-progress: true",
+            "timeout-minutes: 45",
+            "timeout-minutes: 30",
+        )
+        for fragment in required:
+            if fragment not in text:
+                errors.append(f"public CI is missing resource-boundary requirement: {fragment!r}")
+    elif label == ".github/workflows/validation.yml" and "timeout-minutes: 120" not in text:
+        errors.append("validation workflow must retain its 120-minute bounded timeout")
+    elif label == ".github/workflows/publish.yml":
+        for fragment in ("timeout-minutes: 60", "timeout-minutes: 15"):
+            if fragment not in text:
+                errors.append(
+                    f"publish workflow is missing resource-boundary requirement: {fragment!r}"
+                )
+
+
 def _check_publish_workflow(root: Path, errors: list[str]) -> None:
     path = root / ".github/workflows/publish.yml"
     if not path.is_file():
@@ -112,6 +145,10 @@ def _check_publish_workflow(root: Path, errors: list[str]) -> None:
         "python scripts/release_check.py --require-release-evidence",
         "scripts/history_scan.py",
         "git merge-base --is-ancestor",
+        "ref: ${{ github.event.release.tag_name }}",
+        "python scripts/verify_release_tag.py",
+        "--allowed-signers .github/release-signers",
+        "--expected-principal XiantingWu",
     )
     for fragment in required_fragments:
         if fragment not in publish:
@@ -121,3 +158,9 @@ def _check_publish_workflow(root: Path, errors: list[str]) -> None:
             errors.append(
                 f"publish workflow must not contain long-lived credential input: {fragment!r}"
             )
+    if "github.event.release.target_commitish" in publish:
+        errors.append("publish workflow must check out the release tag, not target_commitish")
+    if "grep -Eq" in publish and "SIGNATURE" in publish:
+        errors.append(
+            "publish workflow must use cryptographic tag verification, not signature-block text"
+        )

--- a/scripts/verify_release_tag.py
+++ b/scripts/verify_release_tag.py
@@ -1,0 +1,161 @@
+"""Verify a release tag with the repository-pinned public signer policy."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+_TAG_NAME = re.compile(r"^v\d+\.\d+\.\d+$")
+_SSH_KEY_TYPES = frozenset(
+    {
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "sk-ssh-ed25519@openssh.com",
+        "ssh-dss",
+        "ssh-ed25519",
+        "ssh-rsa",
+    }
+)
+
+
+def _allowed_signers_path(root: Path, requested: Path, errors: list[str]) -> Path | None:
+    candidate = requested if requested.is_absolute() else root / requested
+    if candidate.is_symlink():
+        errors.append("release signer policy must not be a symlink")
+        return None
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        errors.append("release signer policy must remain inside the repository")
+        return None
+    if not resolved.is_file():
+        errors.append("release signer policy is not provisioned")
+        return None
+    return resolved
+
+
+def _check_signer_policy(
+    path: Path,
+    *,
+    expected_principal: str,
+    errors: list[str],
+) -> bool:
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        errors.append(f"could not read release signer policy: {exc}")
+        return False
+
+    if "PRIVATE KEY" in contents:
+        errors.append("release signer policy must contain public keys only")
+
+    entries = 0
+    expected_entries = 0
+    for raw_line in contents.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        if len(fields) < 3 or fields[1] not in _SSH_KEY_TYPES:
+            errors.append("release signer policy contains an invalid SSH public-key entry")
+            continue
+        entries += 1
+        if fields[0] == expected_principal:
+            expected_entries += 1
+
+    if entries == 0:
+        errors.append("release signer policy contains no SSH public signer")
+    if expected_entries == 0:
+        errors.append(f"release signer policy does not authorize principal {expected_principal!r}")
+    return not errors
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def verify_release_tag(
+    root: Path = ROOT,
+    *,
+    tag: str,
+    allowed_signers: Path = Path(".github/release-signers"),
+    expected_principal: str = "XiantingWu",
+) -> list[str]:
+    """Return failures for an annotated tag without accepting signature-shaped text.
+
+    The final verification command is the cryptographic ``git verify-tag`` check.
+    """
+
+    root = Path(root).resolve()
+    errors: list[str] = []
+    if not _TAG_NAME.fullmatch(tag):
+        errors.append("release tag must be an exact vMAJOR.MINOR.PATCH name")
+
+    policy = _allowed_signers_path(root, Path(allowed_signers), errors)
+    if policy is not None:
+        _check_signer_policy(policy, expected_principal=expected_principal, errors=errors)
+
+    tag_type = _git(root, "cat-file", "-t", tag)
+    if tag_type.returncode != 0 or tag_type.stdout.strip() != "tag":
+        errors.append("release tag must point to an annotated tag object")
+
+    if policy is None or errors:
+        return errors
+
+    verified = _git(
+        root,
+        "-c",
+        "gpg.format=ssh",
+        "-c",
+        f"gpg.ssh.allowedSignersFile={policy}",
+        "verify-tag",
+        "--raw",
+        tag,
+    )
+    if verified.returncode != 0:
+        errors.append(
+            "release tag cryptographic SSH signature verification failed against the "
+            "repository-pinned allowed-signers policy"
+        )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify an annotated release tag with the pinned public SSH signer policy."
+    )
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--allowed-signers", type=Path, default=Path(".github/release-signers"))
+    parser.add_argument("--expected-principal", default="XiantingWu")
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    errors = verify_release_tag(
+        args.root,
+        tag=args.tag,
+        allowed_signers=args.allowed_signers,
+        expected_principal=args.expected_principal,
+    )
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print(f"PASS: cryptographic SSH verification for annotated tag {args.tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/reproagent/release_provenance.py
+++ b/src/reproagent/release_provenance.py
@@ -18,6 +18,7 @@ _RELEASE_SOURCE_FILES = (
     "scripts/launch_surface_check.py",
     "scripts/release_check.py",
     "scripts/release_source_check.py",
+    "scripts/verify_release_tag.py",
     "scripts/record_release_evidence.py",
     "scripts/run_real_paper_smoke.py",
     "scripts/stamp_release_measurement.py",
@@ -58,9 +59,10 @@ def release_source_files(root: Path) -> tuple[Path, ...]:
     package typing markers, and trusted certification/evidence-production plus
     publish workflows are part of the
     fingerprint because changing those semantics invalidates prior measurements
-    even when core runtime Python bytes are unchanged. External pull-request
-    intake is review-only and therefore has no executable CI workflow in the
-    release source set.
+    even when core runtime Python bytes are unchanged. Public CI workflow bytes
+    are part of release-source identity because fork/main quality policy is
+    release-relevant. External PR execution is GitHub-hosted, secret-free and
+    non-certifying; exact-main validation remains the certification authority.
     """
 
     root = Path(root).resolve()

--- a/tests/test_launch_surface_check.py
+++ b/tests/test_launch_surface_check.py
@@ -62,6 +62,24 @@ def test_current_public_launch_surface_is_complete() -> None:
     assert check_launch_surface(ROOT) == []
 
 
+def test_launch_surface_requires_hardened_evidence_status_language(tmp_path: Path) -> None:
+    root = _surface_copy(tmp_path)
+    checklist = root / "docs/PUBLIC_RELEASE_CHECKLIST.md"
+    checklist.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ROOT / "docs/PUBLIC_RELEASE_CHECKLIST.md", checklist)
+    checklist.write_text(
+        checklist.read_text(encoding="utf-8").replace(
+            "previous source/fingerprint/run are labelled historical after release-relevant hardening",
+            "previous evidence is historical",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = check_launch_surface(root)
+
+    assert any("historical from current 0.8 evidence" in error for error in errors)
+
+
 def test_public_docs_are_standalone_facing() -> None:
     for relative in _PUBLIC_DOCS:
         text = (ROOT / relative).read_text(encoding="utf-8")

--- a/tests/test_public_ci_contract.py
+++ b/tests/test_public_ci_contract.py
@@ -107,3 +107,42 @@ def test_compatibility_matrix_covers_python_312_and_313() -> None:
     assert "python-version: '3.11'" in ci
     assert "python-version: '3.12'" in ci
     assert "python-version: '3.13'" in ci
+
+
+def test_ci_cancels_stale_same_pr_or_branch_runs() -> None:
+    ci = _workflow("ci.yml")
+    assert "concurrency:" in ci
+    assert (
+        "group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+        in ci
+    )
+    assert "cancel-in-progress: true" in ci
+
+
+def test_all_public_ci_jobs_have_explicit_timeouts() -> None:
+    ci = _workflow("ci.yml")
+    assert ci.count("timeout-minutes:") == 3
+    assert "timeout-minutes: 45" in ci
+    assert ci.count("timeout-minutes: 30") == 2
+
+
+def test_publish_checks_out_release_tag() -> None:
+    publish = _workflow("publish.yml")
+    assert "ref: ${{ github.event.release.tag_name }}" in publish
+
+
+def test_publish_does_not_checkout_target_commitish() -> None:
+    publish = _workflow("publish.yml")
+    assert "github.event.release.target_commitish" not in publish
+
+
+def test_publish_requires_cryptographic_tag_verification() -> None:
+    publish = _workflow("publish.yml")
+    assert "python scripts/verify_release_tag.py" in publish
+    assert "--allowed-signers .github/release-signers" in publish
+    assert "git verify-tag" in (ROOT / "scripts/verify_release_tag.py").read_text(encoding="utf-8")
+
+
+def test_publish_rejects_signature_block_only_policy() -> None:
+    publish = _workflow("publish.yml")
+    assert "grep -Eq" not in publish

--- a/tests/test_public_contract_surface.py
+++ b/tests/test_public_contract_surface.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from scripts.release_checks.public_contract_surface import (
+    PUBLIC_CONTRACT_FILES,
+    check_public_contract_surface,
+)
+
+ROOT = Path(__file__).parents[1]
+
+
+def _contract_copy(tmp_path: Path) -> Path:
+    for relative in PUBLIC_CONTRACT_FILES:
+        source = ROOT / relative
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+    return tmp_path
+
+
+def test_public_contract_accepts_current_architecture() -> None:
+    errors: list[str] = []
+
+    check_public_contract_surface(ROOT, errors)
+
+    assert errors == []
+
+
+def test_public_contract_rejects_review_only_pr_claim(tmp_path: Path) -> None:
+    root = _contract_copy(tmp_path)
+    path = root / "CONTRIBUTING.md"
+    path.write_text(
+        path.read_text(encoding="utf-8") + "\nExternal/fork pull requests are review-only.\n",
+        encoding="utf-8",
+    )
+    errors: list[str] = []
+
+    check_public_contract_surface(root, errors)
+
+    assert any("review-only" in error for error in errors)
+
+
+def test_public_contract_rejects_self_hosted_certification_claim(tmp_path: Path) -> None:
+    root = _contract_copy(tmp_path)
+    path = root / "docs/TRUST_MODEL.md"
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + "\nThe exact-head self-hosted certification is authoritative.\n",
+        encoding="utf-8",
+    )
+    errors: list[str] = []
+
+    check_public_contract_surface(root, errors)
+
+    assert any("self-hosted certification" in error for error in errors)
+
+
+def test_public_contract_rejects_automatic_writeback_claim(tmp_path: Path) -> None:
+    root = _contract_copy(tmp_path)
+    path = root / "docs/PUBLISHING.md"
+    path.write_text(
+        path.read_text(encoding="utf-8") + "\nA separate writeback job promotes the files.\n",
+        encoding="utf-8",
+    )
+    errors: list[str] = []
+
+    check_public_contract_surface(root, errors)
+
+    assert any("writeback" in error for error in errors)
+
+
+def test_public_contract_rejects_missing_github_hosted_pr_ci_claim(tmp_path: Path) -> None:
+    root = _contract_copy(tmp_path)
+    path = root / "CONTRIBUTING.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("GitHub-hosted PR CI", "PR CI"),
+        encoding="utf-8",
+    )
+    errors: list[str] = []
+
+    check_public_contract_surface(root, errors)
+
+    assert any("GitHub-hosted PR CI" in error for error in errors)

--- a/tests/test_release_check_layers.py
+++ b/tests/test_release_check_layers.py
@@ -102,7 +102,7 @@ def test_security_surface_accepts_canonical_private_advisory_route(tmp_path: Pat
         "- double opt-in GPU device access\n"
         "- Public pull requests and CI isolation\n"
         "- private vulnerability-reporting flow\n"
-        "- Do not execute external fork pull-request code on persistent self-hosted runners\n",
+        "- No self-hosted execution and no `pull_request_target` may be used for contributor code\n",
         encoding="utf-8",
     )
     (tmp_path / ".github/ISSUE_TEMPLATE/config.yml").write_text(
@@ -121,7 +121,7 @@ def test_security_surface_rejects_historical_incubator_in_security_md(tmp_path: 
         "double opt-in GPU device access\n"
         "Public pull requests and CI isolation\n"
         "private vulnerability-reporting flow\n"
-        "Do not execute external fork pull-request code on persistent self-hosted runners\n"
+        "No self-hosted execution and no `pull_request_target` may be used for contributor code\n"
         "report to Papers/Repository1-ReproAgent instead\n",
         encoding="utf-8",
     )

--- a/tests/test_release_source_identity.py
+++ b/tests/test_release_source_identity.py
@@ -27,6 +27,7 @@ def _release_tree(root: Path) -> Path:
         "scripts/launch_surface_check.py": "pass\n",
         "scripts/release_check.py": "pass\n",
         "scripts/release_source_check.py": "pass\n",
+        "scripts/verify_release_tag.py": "pass\n",
         "scripts/record_release_evidence.py": "pass\n",
         "scripts/run_real_paper_smoke.py": "pass\n",
         "scripts/stamp_release_measurement.py": "pass\n",
@@ -224,6 +225,15 @@ def test_public_ci_is_part_of_release_source_identity(tmp_path: Path) -> None:
     first = release_source_sha256(root)
     ci = root / ".github/workflows/ci.yml"
     ci.write_text("name: changed hosted CI\n", encoding="utf-8")
+    second = release_source_sha256(root)
+    assert first != second
+
+
+def test_release_tag_verifier_is_part_of_release_source_identity(tmp_path: Path) -> None:
+    root = _release_tree(tmp_path / "release")
+    first = release_source_sha256(root)
+    verifier = root / "scripts/verify_release_tag.py"
+    verifier.write_text("changed verifier\n", encoding="utf-8")
     second = release_source_sha256(root)
     assert first != second
 

--- a/tests/test_release_tag_verification.py
+++ b/tests/test_release_tag_verification.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.verify_release_tag import verify_release_tag
+
+
+def _run(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        list(args),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _tag_repository(tmp_path: Path, *, signed: bool) -> tuple[Path, Path]:
+    root = tmp_path / "tag-repository"
+    root.mkdir()
+    _run("git", "init", "--quiet", cwd=root)
+    _run("git", "config", "user.name", "Test Signer", cwd=root)
+    _run("git", "config", "user.email", "test-signer@example.invalid", cwd=root)
+
+    key = root / "test-signing-key"
+    _run("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key), cwd=root)
+    public_key = key.with_name(f"{key.name}.pub").read_text(encoding="utf-8").strip()
+    allowed_signers = root / "allowed-signers"
+    allowed_signers.write_text(f"XiantingWu {public_key}\n", encoding="utf-8")
+
+    (root / "README").write_text("test\n", encoding="utf-8")
+    _run("git", "add", "README", cwd=root)
+    _run("git", "commit", "--quiet", "-m", "initial", cwd=root)
+    if signed:
+        _run(
+            "git",
+            "-c",
+            "gpg.format=ssh",
+            "-c",
+            f"user.signingkey={key}",
+            "tag",
+            "-s",
+            "-m",
+            "release",
+            "v0.8.0",
+            cwd=root,
+        )
+    else:
+        _run(
+            "git",
+            "tag",
+            "-a",
+            "-m",
+            "-----BEGIN SSH SIGNATURE-----\nfake\n-----END SSH SIGNATURE-----",
+            "v0.8.0",
+            cwd=root,
+        )
+    return root, allowed_signers
+
+
+def test_release_tag_verifier_accepts_valid_test_signature(tmp_path: Path) -> None:
+    root, allowed_signers = _tag_repository(tmp_path, signed=True)
+
+    assert verify_release_tag(root, tag="v0.8.0", allowed_signers=allowed_signers) == []
+
+
+def test_release_tag_verifier_rejects_unsigned_tag(tmp_path: Path) -> None:
+    root, allowed_signers = _tag_repository(tmp_path, signed=False)
+
+    errors = verify_release_tag(root, tag="v0.8.0", allowed_signers=allowed_signers)
+
+    assert any("cryptographic" in error for error in errors)
+
+
+def test_release_tag_verifier_rejects_signature_block_only_tag(tmp_path: Path) -> None:
+    root, allowed_signers = _tag_repository(tmp_path, signed=False)
+
+    errors = verify_release_tag(root, tag="v0.8.0", allowed_signers=allowed_signers)
+
+    assert any("cryptographic" in error for error in errors)
+
+
+def test_release_tag_verifier_rejects_missing_signer_policy(tmp_path: Path) -> None:
+    root, _ = _tag_repository(tmp_path, signed=True)
+
+    errors = verify_release_tag(
+        root,
+        tag="v0.8.0",
+        allowed_signers=Path("missing-signers"),
+    )
+
+    assert any("not provisioned" in error for error in errors)


### PR DESCRIPTION
Summary
- Align contributor, security, trust, support, architecture, and publishing documentation with the GitHub-hosted public CI model.
- Align evidence documentation with sanitized artifact upload and explicit evidence-only PR promotion.
- Add a fail-closed public contract consistency gate and regression tests.
- Add CI timeout/concurrency resource bounds.
- Bind publishing to the release tag and require cryptographic SSH tag verification against a repository-pinned public signer policy.

Verification
- 782 tests
- 86.4% statement coverage / 79.9% branch coverage
- Ruff / format / mypy
- history, release, and launch checks
- build / Twine / clean-wheel verification
- Gitleaks 8.30.1 and TruffleHog 3.97.1 scans

Security
- GitHub-hosted runners only
- read-only, secret-free PR CI
- no self-hosted execution or pull_request_target contributor execution
- no long-lived PyPI token; OIDC remains isolated to the protected publish job

Release signing is fail-closed and intentionally not provisioned in this PR. No release tag, GitHub Release, or PyPI publication is created.
