### PR TITLE
evidence: promote final validation results

### DIFF
--- a/benchmarks/certification-environment-0.8.0.json
+++ b/benchmarks/certification-environment-0.8.0.json
@@ -49,11 +49,11 @@
     "zipp": "4.1.0"
   },
   "provenance": {
-    "github_actions_run_id": "33282504163",
-    "head_sha": "ace6683ff24399ff374eec5c05669b67783ffec9",
+    "github_actions_run_id": "33316585656",
+    "head_sha": "cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef",
     "workflow": "VeriRepro validation"
   },
   "python": "3.11.16",
-  "release_source_sha256": "4cc5f2d80af9f08a5720cfce273c0f0fe8f2e21af586fffad98f5c939af1b4b8",
+  "release_source_sha256": "1032069218c9bbecaf8ec7eda6de48bf704e9552487a26ce828a19c6084d6569",
   "schema_version": 1
 }

--- a/benchmarks/environment-planning-results-0.8.0.json
+++ b/benchmarks/environment-planning-results-0.8.0.json
@@ -19,7 +19,7 @@
     "algorithm_found_rate": 1.0,
     "algorithm_top1_rate": 1.0,
     "algorithm_evidence_anchor_rate": 1.0,
-    "mean_discovery_seconds": 3.455,
+    "mean_discovery_seconds": 3.4563333333333333,
     "discovery_status": {
       "ok": 3
     },
@@ -76,7 +76,7 @@
           "context": "https://github.com/OpenAI/CLIP"
         }
       ],
-      "discovery_seconds": 4.881,
+      "discovery_seconds": 4.845,
       "top_candidate": "https://github.com/OpenAI/CLIP",
       "candidate_count": 2,
       "candidates": [
@@ -102,7 +102,7 @@
       ],
       "repository_inspection": {
         "status": "planned",
-        "duration_seconds": 0.487,
+        "duration_seconds": 0.775,
         "commit_sha": "d05afc436d78f1c48dc0dbf8e5980a9d471f35f6",
         "python_version": "3.11",
         "python_source": "verirepro-default",
@@ -144,7 +144,7 @@
           "context": "https://github.com/microsoft/LoRA"
         }
       ],
-      "discovery_seconds": 4.811,
+      "discovery_seconds": 5.017,
       "top_candidate": "https://github.com/microsoft/LoRA",
       "candidate_count": 1,
       "candidates": [
@@ -161,7 +161,7 @@
       ],
       "repository_inspection": {
         "status": "planned",
-        "duration_seconds": 1.288,
+        "duration_seconds": 1.731,
         "commit_sha": "c4593f060e6a368d7bb5af5273b8e42810cdef90",
         "python_version": "3.11",
         "python_source": "verirepro-default",
@@ -201,7 +201,7 @@
           "context": "https://github.com/google-research/ALBERT"
         }
       ],
-      "discovery_seconds": 0.673,
+      "discovery_seconds": 0.507,
       "top_candidate": "https://github.com/google-research/ALBERT",
       "candidate_count": 2,
       "candidates": [
@@ -226,7 +226,7 @@
       ],
       "repository_inspection": {
         "status": "planned",
-        "duration_seconds": 0.288,
+        "duration_seconds": 0.608,
         "commit_sha": "b772393d3dae115b493258ce8e37c17b2cc62100",
         "python_version": "3.11",
         "python_source": "verirepro-default",
@@ -247,12 +247,12 @@
   ],
   "measurement_provenance": {
     "workflow": "VeriRepro validation",
-    "github_actions_run_id": "33282504163",
-    "head_sha": "ace6683ff24399ff374eec5c05669b67783ffec9"
+    "github_actions_run_id": "33316585656",
+    "head_sha": "cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef"
   },
   "release": "0.8.0",
   "provenance": {
-    "github_actions_run_id": "33282504163",
-    "head_sha": "ace6683ff24399ff374eec5c05669b67783ffec9"
+    "github_actions_run_id": "33316585656",
+    "head_sha": "cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef"
   }
 }

--- a/benchmarks/real-paper-smoke-results-0.8.0.json
+++ b/benchmarks/real-paper-smoke-results-0.8.0.json
@@ -19,7 +19,7 @@
     "algorithm_found_rate": 1.0,
     "algorithm_top1_rate": 1.0,
     "algorithm_evidence_anchor_rate": 1.0,
-    "mean_discovery_seconds": 2.2897333333333334,
+    "mean_discovery_seconds": 2.8407999999999998,
     "discovery_status": {
       "ok": 15
     },
@@ -142,7 +142,7 @@
           "context": "https://github.com/OpenAI/CLIP"
         }
       ],
-      "discovery_seconds": 4.973,
+      "discovery_seconds": 4.881,
       "top_candidate": "https://github.com/OpenAI/CLIP",
       "candidate_count": 2,
       "candidates": [
@@ -189,7 +189,7 @@
           "context": "https://github.com/microsoft/LoRA"
         }
       ],
-      "discovery_seconds": 4.859,
+      "discovery_seconds": 4.727,
       "top_candidate": "https://github.com/microsoft/LoRA",
       "candidate_count": 1,
       "candidates": [
@@ -227,7 +227,7 @@
           "context": "https://github.com/google-research/ALBERT"
         }
       ],
-      "discovery_seconds": 0.566,
+      "discovery_seconds": 0.614,
       "top_candidate": "https://github.com/google-research/ALBERT",
       "candidate_count": 2,
       "candidates": [
@@ -273,7 +273,7 @@
           "context": "https://github.com/openai/guided-diffusion"
         }
       ],
-      "discovery_seconds": 1.629,
+      "discovery_seconds": 5.226,
       "top_candidate": "https://github.com/openai/guided-diffusion",
       "candidate_count": 3,
       "candidates": [
@@ -320,7 +320,7 @@
           "context": "https://github.com/openai/improved-diffusion"
         }
       ],
-      "discovery_seconds": 1.054,
+      "discovery_seconds": 1.865,
       "top_candidate": "https://github.com/openai/improved-diffusion",
       "candidate_count": 1,
       "candidates": [
@@ -368,7 +368,7 @@
           "context": "https://github.com/facebookresearch/detr"
         }
       ],
-      "discovery_seconds": 0.719,
+      "discovery_seconds": 2.069,
       "top_candidate": "https://github.com/facebookresearch/detr",
       "candidate_count": 2,
       "candidates": [
@@ -410,7 +410,7 @@
           "context": "https://github.com/kimiyoung/transformer-xl"
         }
       ],
-      "discovery_seconds": 0.844,
+      "discovery_seconds": 1.205,
       "top_candidate": "https://github.com/kimiyoung/transformer-xl",
       "candidate_count": 1,
       "candidates": [
@@ -443,7 +443,7 @@
           "context": "https://github.com/google-research/bert"
         }
       ],
-      "discovery_seconds": 0.893,
+      "discovery_seconds": 0.831,
       "top_candidate": "https://github.com/google-research/bert",
       "candidate_count": 1,
       "candidates": [
@@ -476,7 +476,7 @@
           "context": "https://github.com/microsoft/Swin-Transformer"
         }
       ],
-      "discovery_seconds": 0.806,
+      "discovery_seconds": 0.807,
       "top_candidate": "https://github.com/microsoft/Swin-Transformer",
       "candidate_count": 3,
       "candidates": [
@@ -542,7 +542,7 @@
           "context": "https://github.com/SwinTransformer/Transformer-SSL"
         }
       ],
-      "discovery_seconds": 0.483,
+      "discovery_seconds": 0.633,
       "top_candidate": "https://github.com/SwinTransformer/Transformer-SSL",
       "candidate_count": 3,
       "candidates": [
@@ -615,7 +615,7 @@
           "context": "https://github.com/dynamicslab/pysindy/tree/master/example"
         }
       ],
-      "discovery_seconds": 0.483,
+      "discovery_seconds": 0.588,
       "top_candidate": "https://github.com/dynamicslab/pysindy",
       "candidate_count": 2,
       "candidates": [
@@ -655,7 +655,7 @@
           "context": "https://github.com/google/jax-md/"
         }
       ],
-      "discovery_seconds": 12.431,
+      "discovery_seconds": 13.693,
       "top_candidate": "https://github.com/google/jax-md",
       "candidate_count": 3,
       "candidates": [
@@ -702,7 +702,7 @@
           "context": "dap- tive activation function can be used to solve different PDE systems in an interpretable way. Its effectiveness is demonstrated on a series of benchmarks. Code is available at https://github.com/LeapLabTHU/AdaAFforPINNs. AMS subject classifications: 65M99, 68T07 Key words: partial differential equations, deep learning, adaptive activation functions, physics- informed neural networks. 1 Introductio"
         }
       ],
-      "discovery_seconds": 1.821,
+      "discovery_seconds": 2.259,
       "top_candidate": "https://github.com/LeapLabTHU/AdaAFforPINNs",
       "candidate_count": 1,
       "candidates": [
@@ -741,7 +741,7 @@
           "context": "https://github.com/cagalvisf/Quantum_HSGPQ"
         }
       ],
-      "discovery_seconds": 0.978,
+      "discovery_seconds": 1.336,
       "top_candidate": "https://github.com/cagalvisf/Quantum_HSGPQ",
       "candidate_count": 1,
       "candidates": [
@@ -789,7 +789,7 @@
           "context": "https://github.com/ChriPiv/tndecoder3d"
         }
       ],
-      "discovery_seconds": 1.807,
+      "discovery_seconds": 1.878,
       "top_candidate": "https://github.com/ChriPiv/tndecoder3d",
       "candidate_count": 2,
       "candidates": [
@@ -818,12 +818,12 @@
   ],
   "measurement_provenance": {
     "workflow": "VeriRepro validation",
-    "github_actions_run_id": "33282504163",
-    "head_sha": "ace6683ff24399ff374eec5c05669b67783ffec9"
+    "github_actions_run_id": "33316585656",
+    "head_sha": "cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef"
   },
   "release": "0.8.0",
   "provenance": {
-    "github_actions_run_id": "33282504163",
-    "head_sha": "ace6683ff24399ff374eec5c05669b67783ffec9"
+    "github_actions_run_id": "33316585656",
+    "head_sha": "cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef"
   }
 }

--- a/benchmarks/reprobench-results-0.8.0/manifest.json
+++ b/benchmarks/reprobench-results-0.8.0/manifest.json
@@ -3,14 +3,14 @@
   "release": "0.8.0",
   "suite": "benchmarks/reprobench-seed-suite.json",
   "suite_sha256": "dcddb4e81b760392c8e14945e9fe5f6b23691c5b0342b7451e1661576eef36d6",
-  "source_tree_sha256": "4cc5f2d80af9f08a5720cfce273c0f0fe8f2e21af586fffad98f5c939af1b4b8",
+  "source_tree_sha256": "1032069218c9bbecaf8ec7eda6de48bf704e9552487a26ce828a19c6084d6569",
   "cases": [
     {
       "task_id": "governed-individuation-mechanism-v1",
       "task_file": "benchmarks/reprobench-seed/governed-individuation.json",
       "task_sha256": "eed91e4725b13fe3e07befb606df212e39d65a609c6aef1cad21045c4a122c04",
       "result_file": "results/governed-individuation-mechanism-v1.json",
-      "result_sha256": "1363e3159dcf5e934e533412058980710b8fc2a7db2891604be41d76e299bd63",
+      "result_sha256": "c63085a02e172d5b847ec677bba601b73b5f77b638c2b445f3aeb9e5bae94979",
       "repository_ref": "010f4d716db5fa0f1defbb2b5f4afa11ab566fe1",
       "scientific_references": [],
       "gate_passed": true,
@@ -21,7 +21,7 @@
       "task_file": "benchmarks/reprobench-seed/cohomology-wall.json",
       "task_sha256": "7500e6be55b589c22037d04d2a2779e6fb0c5cb79e1c423669665c00d15a5c83",
       "result_file": "results/cohomology-wall-smoke-v1.json",
-      "result_sha256": "2d6cc017e77519c96d1fe0b20ed3c40f52ba7d5ccb3c8dd1242f9a16929b17e0",
+      "result_sha256": "6e9a9c762702ecf46b2a761659589f0d11f28b28c3ac6f1f7da7a5feab7971b7",
       "repository_ref": "a29fbbc9b4b8f6260cee90e5cd77f90c6ef3c704",
       "scientific_references": [
         {
@@ -34,11 +34,11 @@
     }
   ],
   "summary_file": "summary.json",
-  "summary_sha256": "b4b15ce808952de0a1ba9789a7b3e279b617bacebdd3cf0f9889eab68909a35a",
+  "summary_sha256": "8d26284c33185ced2288fb990c3becc35b0fd5f51f641435d930a43845a967df",
   "gate_passed": true,
   "provenance": {
     "workflow": "VeriRepro validation",
-    "github_actions_run_id": "33282504163",
-    "head_sha": "ace6683ff24399ff374eec5c05669b67783ffec9"
+    "github_actions_run_id": "33316585656",
+    "head_sha": "cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef"
   }
 }

--- a/benchmarks/reprobench-results-0.8.0/results/cohomology-wall-smoke-v1.json
+++ b/benchmarks/reprobench-results-0.8.0/results/cohomology-wall-smoke-v1.json
@@ -17,7 +17,7 @@
     "report_schema_version": 1
   },
   "outcome": "success",
-  "wall_clock_seconds": 17.208022,
+  "wall_clock_seconds": 17.277867,
   "execution_requested": true,
   "operator_interventions": [
     "repository_override",

--- a/benchmarks/reprobench-results-0.8.0/results/governed-individuation-mechanism-v1.json
+++ b/benchmarks/reprobench-results-0.8.0/results/governed-individuation-mechanism-v1.json
@@ -15,7 +15,7 @@
     "report_schema_version": 1
   },
   "outcome": "partial",
-  "wall_clock_seconds": 27.213694,
+  "wall_clock_seconds": 28.75966,
   "execution_requested": true,
   "operator_interventions": [
     "repository_override",

--- a/benchmarks/reprobench-results-0.8.0/summary.json
+++ b/benchmarks/reprobench-results-0.8.0/summary.json
@@ -5,12 +5,12 @@
   "inputs": [
     {
       "file": "cohomology-wall-smoke-v1.json",
-      "sha256": "2d6cc017e77519c96d1fe0b20ed3c40f52ba7d5ccb3c8dd1242f9a16929b17e0",
+      "sha256": "6e9a9c762702ecf46b2a761659589f0d11f28b28c3ac6f1f7da7a5feab7971b7",
       "task_id": "cohomology-wall-smoke-v1"
     },
     {
       "file": "governed-individuation-mechanism-v1.json",
-      "sha256": "1363e3159dcf5e934e533412058980710b8fc2a7db2891604be41d76e299bd63",
+      "sha256": "c63085a02e172d5b847ec677bba601b73b5f77b638c2b445f3aeb9e5bae94979",
       "task_id": "governed-individuation-mechanism-v1"
     }
   ],
@@ -26,9 +26,9 @@
     "zero_intervention_cases": 0,
     "zero_intervention_rate": 0.0,
     "interventions_total": 7,
-    "wall_clock_seconds_total": 44.421716,
-    "wall_clock_seconds_mean": 22.210858,
-    "wall_clock_seconds_median": 22.210858,
+    "wall_clock_seconds_total": 46.037527,
+    "wall_clock_seconds_mean": 23.018763,
+    "wall_clock_seconds_median": 23.018763,
     "environment_build": {
       "statuses": {
         "passed": 2


### PR DESCRIPTION
Summary

- Promote only the sanitized evidence emitted by the final GitHub-hosted validation run.
- Bind discovery, planning, certification environment, and ReproBench evidence to the exact final source.

Provenance

- source SHA: cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef
- release-source fingerprint: 1032069218c9bbecaf8ec7eda6de48bf704e9552487a26ce828a19c6084d6569
- validation run: 33316585656
- evidence files are sanitized and version-matched

Verification

- release check with evidence PASS
- release-source identity PASS
- no source or workflow changes in this PR