### PR TITLE
release: repair PyPI delivery and prepare 0.8.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,4 +146,4 @@ jobs:
           name: verirepro-dist-${{ github.run_id }}
           path: dist/
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2 dereferenced release commit

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      VERIREPRO_RELEASE_VERSION: 0.8.0
+      VERIREPRO_RELEASE_VERSION: 0.8.1
       VERIREPRO_SOURCE_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,6 +55,12 @@ jobs:
             --output "$RUNNER_TEMP/verirepro-validation/certification-environment.json" \
             --run-id "$GITHUB_RUN_ID" \
             --head-sha "$VERIREPRO_SOURCE_SHA"
+      - name: Preflight exact PyPI publisher runtime image
+        run: |
+          set -euo pipefail
+          docker manifest inspect \
+            ghcr.io/pypa/gh-action-pypi-publish:dc37677b2e1c63e2034f94d8a5b11f265b73ba33 \
+            >/dev/null
       - name: Measure 15-paper discovery gate
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Notable user-facing changes are recorded here. Internal CI incidents and one-off maintainer infrastructure details are intentionally omitted from public release notes.
 
+## 0.8.1 — release-delivery correction
+
+- correct the PyPI Trusted Publishing action pin so the v1.14.2 annotated
+  upstream tag is pinned by its dereferenced release commit rather than its
+  tag-object SHA;
+- add regression coverage for annotated GitHub Action tag dereferencing;
+- add release validation of the exact PyPI action container image before a
+  candidate is certified;
+- no scientific runtime, reproduction semantics, or public API behavior is
+  intentionally changed by this patch;
+- the v0.8.0 GitHub release completed, but its first PyPI delivery did not
+  upload distributions because the publishing action used an annotated tag
+  object SHA without a corresponding runtime image.
+
 ## 0.8.0 — hardened runtime, verification, and release engineering
 
 0.4–0.7 were pre-public development milestones; 0.8.0 is the first planned stable public package publication.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "VeriRepro: Evidence-grounded computational paper reproduction"
 type: software
 authors:
   - name: "VeriRepro contributors"
-version: 0.8.0
+version: 0.8.1
 license: Apache-2.0
 repository-code: "https://github.com/XiantingWu/VeriRepro"
 url: "https://github.com/XiantingWu/VeriRepro"

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
-# Public Release Checklist (0.8.0)
+# Public Release Checklist (0.8.1)
 
-Status: **pre-release engineering freeze complete.** Stable GitHub Release/PyPI publication remains separately unauthorized.
+Status: **release-delivery repair candidate; not yet released.**
 
 ## Runner architecture
 
@@ -40,6 +40,8 @@ Status: **pre-release engineering freeze complete.** Stable GitHub Release/PyPI 
 - [x] no long-lived PyPI token; publish refuses pre-release events
 - [x] publish re-runs release/launch/history/source/evidence gates before building
 - [x] release signer policy public key is provisioned; no stable tag may be created before the policy is verified
+- [x] v1.14.2 PyPI publisher action is pinned to its dereferenced release commit; the annotated tag-object SHA is not used
+- [ ] exact PyPI publisher runtime-image manifest preflight passes for the 0.8.1 candidate
 
 ## Release signer
 
@@ -68,27 +70,41 @@ Status: **pre-release engineering freeze complete.** Stable GitHub Release/PyPI 
 - [x] CodeQL Default Setup enabled and successful on GitHub-hosted analysis
 - [x] CODEOWNERS assigns XiantingWu as owner for release-sensitive paths
 
-## Evidence
+## Historical v0.8.0 evidence
 
 - [x] previous source/fingerprint/run are labelled historical after release-relevant hardening
-- [x] fresh certification completed once on exact final hardening main `cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef` in validation run `33316585656`
-- [x] fresh evidence (sanitized) promoted by explicit evidence-only PR as `e262560c4be81b8de1f890ca0effc315b3d6b3f0`
+- [x] v0.8.0 certification completed on `cd0c962cbf72ebcecea7f5e6af56b98c4d5576ef` in validation run `33316585656`
+- [x] v0.8.0 evidence (sanitized) promoted by explicit evidence-only PR as `e262560c4be81b8de1f890ca0effc315b3d6b3f0`
 - [x] S1 `ace6683ff24399ff374eec5c05669b67783ffec9`, F1 `4cc5f2d80af9f08a5720cfce273c0f0fe8f2e21af586fffad98f5c939af1b4b8`, old validation, and E1 are labelled historical
 - [x] `docs/EVIDENCE.md` distinguishes historical from current evidence and records scientific limits
+
+## Active v0.8.1 candidate
+
+- [ ] source-hardening main `S3` frozen after the repair PR
+- [ ] release-source fingerprint `F3` computed and different from historical F2
+- [ ] fresh certification (`Validation3`) completed on exact `S3`
+- [ ] fresh evidence (`E3`) sanitized and promoted by an evidence-only PR
+- [ ] `docs/EVIDENCE.md` updated with S3/F3/Validation3/E3 authority
 
 ## Final quality target
 
 - [x] historical validation recorded 782 tests with 86.4% statement coverage and 79.9% branch coverage
-- [x] current validation recorded 792 tests with 86.4% statement coverage and 79.9% branch coverage
-- [x] build / Twine / independent clean-wheel and clean-sdist install PASS recorded after hardening
+- [x] v0.8.0 historical validation recorded 792 tests with 86.4% statement coverage and 79.9% branch coverage
+- [ ] 0.8.1 build / Twine / independent clean-wheel and clean-sdist install PASS recorded after repair
 - [x] native history scan, Gitleaks, and TruffleHog PASS recorded at final audit
 - [x] public launch surface, anonymous clone, and quick start PASS re-verified at final audit
 - [x] full reachable Git history contains zero private runner / host identity metadata
 - [x] TruffleHog verified secrets = 0; unknown/unreviewed candidates = 0; three synthetic fixture candidates reviewed separately
 
-## Deferred (explicit authorization required)
+## Immutable v0.8.0 history
 
-- [ ] signed annotated tag `v0.8.0`
-- [ ] GitHub Release
+- [x] signed annotated tag `v0.8.0` preserved
+- [x] GitHub Release `v0.8.0` preserved as published non-prerelease
+- [x] PyPI `verirepro==0.8.0` was not published; no upload was attempted after the deterministic publisher-image failure
+
+## Deferred 0.8.1 publication
+
+- [ ] signed annotated tag `v0.8.1`
+- [ ] GitHub Release `v0.8.1`
 - [ ] PyPI Trusted Publishing publication
 - [ ] live fork PR smoke on a second account (static contract PASS; deferred pending an independent authorized public fork identity)

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -10,7 +10,7 @@ A release is allowed only when all of the following are true:
 2. `python scripts/launch_surface_check.py` passes and confirms canonical repository URLs, the private-advisory security route, dependency-update automation, and stable-only PyPI publication.
 3. The GitHub-hosted CI workflow passes Ruff, the configured mypy surface, branch-coverage measurement, tests, release/launch checks, distribution build, Twine validation, and independent clean-wheel and clean-sdist installation on the exact candidate SHA.
 4. Measured coverage meets the release floor of at least 85% statement coverage and 75% branch coverage.
-5. `python scripts/release_check.py --require-release-evidence` passes on the exact release tree. For 0.8, this requires version-matched 15-paper discovery evidence, bounded 3-repository environment-planning evidence, and version-matched ReproBench evidence.
+5. `python scripts/release_check.py --require-release-evidence` passes on the exact release tree. For 0.8+, this requires version-matched 15-paper discovery evidence, bounded 3-repository environment-planning evidence, and version-matched ReproBench evidence.
 6. `python scripts/release_source_check.py` confirms that release-relevant runtime/package/measurement/promotion/public-launch/release-policy, dependency-update, dependency-review, and workflow bytes are identical to the source fingerprint recorded by the trusted validation run.
 7. External/fork pull requests run only on GitHub-hosted ephemeral runners with read-only permissions and no secrets; maintainer-owned or persistent infrastructure never executes contributor-controlled code.
 8. The repository has a `pypi` GitHub Environment configured with protection rules and required manual approval.
@@ -87,6 +87,20 @@ GitHub-hosted runner. It fails on high-severity dependency findings, uses no
 secrets or write permissions, and is a required `main` status check after the
 workflow has first been verified on a pull request.
 
+## Publisher action pinning
+
+Third-party GitHub Actions must be pinned to dereferenced commit SHAs. For an
+annotated upstream tag, the tag-object SHA is not a valid substitute for the
+release commit SHA. The v1.14.2 `pypa/gh-action-pypi-publish` action is pinned
+to its dereferenced release commit `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`,
+not the annotated tag-object SHA `a892a5a61159132606e93a2fa6f4358831b04d26`.
+
+Because Docker-based publishing actions can resolve a runtime image from
+`github.action_ref`, the validation workflow performs a read-only manifest
+availability preflight for the exact commit image before a candidate is
+certified. This preflight does not request OIDC credentials or upload to
+PyPI.
+
 If repository setup requires a release-relevant source change, stop and produce fresh trusted evidence from the changed source before release. Documentation-only changes remain outside the release-source fingerprint.
 
 ## PyPI Trusted Publishing
@@ -145,9 +159,9 @@ The publish workflow checks out the release tag, refuses a tag that does not equ
 Release evidence is measurement output, not hand-authored marketing data. A trusted exact-head validation run produces:
 
 ```text
-benchmarks/real-paper-smoke-results-0.8.0.json
-benchmarks/environment-planning-results-0.8.0.json
-benchmarks/reprobench-results-0.8.0/
+benchmarks/real-paper-smoke-results-X.Y.Z.json
+benchmarks/environment-planning-results-X.Y.Z.json
+benchmarks/reprobench-results-X.Y.Z/
   manifest.json
   summary.json
   results/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "verirepro"
-version = "0.8.0"
+version = "0.8.1"
 description = "Evidence-grounded agent for verifiable computational paper reproduction"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/scripts/release_checks/action_pin.py
+++ b/scripts/release_checks/action_pin.py
@@ -1,0 +1,74 @@
+"""Pure helpers for resolving annotated GitHub Action tag references."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish"
+PYPI_PUBLISH_ACTION_VERSION = "v1.14.2"
+PYPI_PUBLISH_ACTION_TAG_OBJECT_SHA = "a892a5a61159132606e93a2fa6f4358831b04d26"
+PYPI_PUBLISH_ACTION_COMMIT_SHA = "dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
+PYPI_PUBLISH_ACTION_IMAGE = f"ghcr.io/{PYPI_PUBLISH_ACTION}:{PYPI_PUBLISH_ACTION_COMMIT_SHA}"
+MAX_TAG_DEREFERENCE_DEPTH = 8
+
+_GIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class ActionPinResolutionError(ValueError):
+    """Raised when a GitHub ref cannot be resolved to a commit safely."""
+
+
+def _object_record(payload: Any, *, label: str) -> tuple[str, str]:
+    if not isinstance(payload, Mapping):
+        raise ActionPinResolutionError(f"{label} payload must be an object")
+    obj = payload.get("object")
+    if not isinstance(obj, Mapping):
+        raise ActionPinResolutionError(f"{label} payload is missing an object")
+
+    object_type = obj.get("type")
+    object_sha = obj.get("sha")
+    if not isinstance(object_type, str) or object_type not in {"commit", "tag"}:
+        raise ActionPinResolutionError(f"{label} has unsupported object type")
+    if not isinstance(object_sha, str) or not _GIT_SHA.fullmatch(object_sha):
+        raise ActionPinResolutionError(f"{label} has an invalid object SHA")
+    return object_type, object_sha.lower()
+
+
+def resolve_action_ref_commit(
+    ref_payload: Mapping[str, Any],
+    tag_payloads: Mapping[str, Mapping[str, Any]],
+    *,
+    max_tag_depth: int = MAX_TAG_DEREFERENCE_DEPTH,
+) -> str:
+    """Resolve a GitHub ref payload to its final commit SHA.
+
+    ``ref_payload`` and ``tag_payloads`` are deterministic API-shaped fixtures;
+    this helper deliberately performs no network access. Annotated tags are
+    followed until a commit is reached, with bounded depth and cycle checks.
+    """
+
+    if (
+        isinstance(max_tag_depth, bool)
+        or not isinstance(max_tag_depth, int)
+        or not 0 <= max_tag_depth <= MAX_TAG_DEREFERENCE_DEPTH
+    ):
+        raise ActionPinResolutionError("max_tag_depth is outside the safe bound")
+
+    object_type, object_sha = _object_record(ref_payload, label="ref")
+    seen_tags: set[str] = set()
+    for depth in range(max_tag_depth + 1):
+        if object_type == "commit":
+            return object_sha
+        if object_sha in seen_tags:
+            raise ActionPinResolutionError("tag dereference cycle detected")
+        if depth >= max_tag_depth:
+            raise ActionPinResolutionError("tag dereference depth exceeded")
+        seen_tags.add(object_sha)
+        nested_payload = tag_payloads.get(object_sha)
+        if nested_payload is None:
+            raise ActionPinResolutionError(f"missing tag payload for {object_sha}")
+        object_type, object_sha = _object_record(nested_payload, label=f"tag {object_sha}")
+
+    raise ActionPinResolutionError("tag dereference depth exceeded")

--- a/scripts/release_checks/workflow_surface.py
+++ b/scripts/release_checks/workflow_surface.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from .action_pin import (
+    PYPI_PUBLISH_ACTION,
+    PYPI_PUBLISH_ACTION_COMMIT_SHA,
+    PYPI_PUBLISH_ACTION_IMAGE,
+    PYPI_PUBLISH_ACTION_TAG_OBJECT_SHA,
+)
 from .common import workflow_runs_on_lines, workflow_uses_lines
 
 HOSTED_RUNNERS = ("ubuntu-latest", "macos-latest", "windows-latest")
@@ -40,6 +46,7 @@ def check_workflow_surface(root: Path, errors: list[str]) -> None:
 
     _check_publish_workflow(root, errors)
     _check_dependency_review_workflow(root, errors)
+    _check_validation_workflow(root, errors)
 
 
 def _check_runner_policy(text: str, *, label: str, errors: list[str]) -> None:
@@ -154,6 +161,7 @@ def _check_publish_workflow(root: Path, errors: list[str]) -> None:
     for fragment in required_fragments:
         if fragment not in publish:
             errors.append(f"publish workflow missing release safety requirement: {fragment!r}")
+    _check_pypi_action_pin(publish, errors)
     current_head_gate = (
         'TAG_COMMIT="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"',
         'MAIN_COMMIT="$(git rev-parse origin/main)"',
@@ -200,4 +208,33 @@ def _check_dependency_review_workflow(root: Path, errors: list[str]) -> None:
         if fragment in text:
             errors.append(
                 f"dependency-review workflow must not request privileged or secret access: {fragment!r}"
+            )
+
+
+def _check_pypi_action_pin(text: str, errors: list[str]) -> None:
+    expected = f"{PYPI_PUBLISH_ACTION}@{PYPI_PUBLISH_ACTION_COMMIT_SHA}"
+    if expected not in text:
+        errors.append(
+            "publish workflow must pin the PyPI action to its dereferenced release commit"
+        )
+    incorrect = f"{PYPI_PUBLISH_ACTION}@{PYPI_PUBLISH_ACTION_TAG_OBJECT_SHA}"
+    if incorrect in text:
+        errors.append("publish workflow must not use the annotated tag-object SHA as an action pin")
+
+
+def _check_validation_workflow(root: Path, errors: list[str]) -> None:
+    path = root / ".github/workflows/validation.yml"
+    if not path.is_file():
+        errors.append("missing public validation workflow")
+        return
+    text = path.read_text(encoding="utf-8")
+    for fragment in ("docker manifest inspect", PYPI_PUBLISH_ACTION_IMAGE):
+        if fragment not in text:
+            errors.append(
+                f"validation workflow must preflight the exact PyPI action runtime image: {fragment!r}"
+            )
+    for fragment in ("id-token: write", "PYPI_API_TOKEN", "password:", "username:"):
+        if fragment in text:
+            errors.append(
+                f"validation workflow image preflight must not request publishing credentials: {fragment!r}"
             )

--- a/src/reproagent/__init__.py
+++ b/src/reproagent/__init__.py
@@ -9,4 +9,4 @@ from .core import ReproductionPlan, build_reproduction_plan
 from .pipeline import reproduce
 
 __all__ = ["ReproductionPlan", "build_reproduction_plan", "reproduce"]
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/tests/test_action_pin.py
+++ b/tests/test_action_pin.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.release_checks.action_pin import (
+    ActionPinResolutionError,
+    resolve_action_ref_commit,
+)
+
+
+def _payload(object_type: str, sha: str) -> dict[str, dict[str, str]]:
+    return {"object": {"type": object_type, "sha": sha}}
+
+
+def test_resolves_lightweight_tag_ref_to_commit() -> None:
+    commit = "c" * 40
+
+    assert resolve_action_ref_commit(_payload("commit", commit), {}) == commit
+
+
+def test_resolves_annotated_tag_ref_to_commit() -> None:
+    tag_object = "a" * 40
+    commit = "c" * 40
+
+    assert (
+        resolve_action_ref_commit(
+            _payload("tag", tag_object),
+            {tag_object: _payload("commit", commit)},
+        )
+        == commit
+    )
+
+
+def test_resolves_nested_annotated_tags_to_commit() -> None:
+    outer_tag = "a" * 40
+    inner_tag = "b" * 40
+    commit = "c" * 40
+
+    assert (
+        resolve_action_ref_commit(
+            _payload("tag", outer_tag),
+            {
+                outer_tag: _payload("tag", inner_tag),
+                inner_tag: _payload("commit", commit),
+            },
+        )
+        == commit
+    )
+
+
+def test_rejects_unsupported_object_type() -> None:
+    with pytest.raises(ActionPinResolutionError, match="unsupported object type"):
+        resolve_action_ref_commit(_payload("tree", "d" * 40), {})
+
+
+def test_rejects_blob_object_type() -> None:
+    with pytest.raises(ActionPinResolutionError, match="unsupported object type"):
+        resolve_action_ref_commit(_payload("blob", "d" * 40), {})
+
+
+def test_rejects_malformed_sha() -> None:
+    with pytest.raises(ActionPinResolutionError, match="invalid object SHA"):
+        resolve_action_ref_commit(_payload("commit", "not-a-sha"), {})
+
+
+def test_rejects_excessive_tag_recursion() -> None:
+    outer_tag = "a" * 40
+    inner_tag = "b" * 40
+    commit = "c" * 40
+
+    with pytest.raises(ActionPinResolutionError, match="depth exceeded"):
+        resolve_action_ref_commit(
+            _payload("tag", outer_tag),
+            {
+                outer_tag: _payload("tag", inner_tag),
+                inner_tag: _payload("commit", commit),
+            },
+            max_tag_depth=1,
+        )
+
+
+def test_rejects_tag_cycle() -> None:
+    first_tag = "a" * 40
+    second_tag = "b" * 40
+
+    with pytest.raises(ActionPinResolutionError, match="cycle"):
+        resolve_action_ref_commit(
+            _payload("tag", first_tag),
+            {
+                first_tag: _payload("tag", second_tag),
+                second_tag: _payload("tag", first_tag),
+            },
+        )

--- a/tests/test_public_ci_contract.py
+++ b/tests/test_public_ci_contract.py
@@ -4,6 +4,12 @@ import re
 import shutil
 from pathlib import Path
 
+from scripts.release_checks.action_pin import (
+    PYPI_PUBLISH_ACTION,
+    PYPI_PUBLISH_ACTION_COMMIT_SHA,
+    PYPI_PUBLISH_ACTION_IMAGE,
+    PYPI_PUBLISH_ACTION_TAG_OBJECT_SHA,
+)
 from scripts.release_checks.workflow_surface import check_workflow_surface
 
 ROOT = Path(__file__).parents[1]
@@ -149,6 +155,37 @@ def test_publish_requires_cryptographic_tag_verification() -> None:
 def test_publish_rejects_signature_block_only_policy() -> None:
     publish = _workflow("publish.yml")
     assert "grep -Eq" not in publish
+
+
+def test_publish_uses_dereferenced_pypi_action_commit() -> None:
+    publish = _workflow("publish.yml")
+    assert f"{PYPI_PUBLISH_ACTION}@{PYPI_PUBLISH_ACTION_COMMIT_SHA}" in publish
+    assert f"{PYPI_PUBLISH_ACTION}@{PYPI_PUBLISH_ACTION_TAG_OBJECT_SHA}" not in publish
+
+
+def test_publish_annotated_tag_object_sha_is_rejected(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".github/workflows"
+    workflow_dir.mkdir(parents=True)
+    for path in WORKFLOWS.glob("*.yml"):
+        shutil.copyfile(path, workflow_dir / path.name)
+    publish_path = workflow_dir / "publish.yml"
+    publish = publish_path.read_text(encoding="utf-8")
+    publish_path.write_text(
+        publish.replace(PYPI_PUBLISH_ACTION_COMMIT_SHA, PYPI_PUBLISH_ACTION_TAG_OBJECT_SHA),
+        encoding="utf-8",
+    )
+
+    errors: list[str] = []
+    check_workflow_surface(tmp_path, errors)
+
+    assert any("tag-object SHA" in item for item in errors)
+
+
+def test_validation_preflights_exact_pypi_action_runtime_image() -> None:
+    validation = _workflow("validation.yml")
+    assert "docker manifest inspect" in validation
+    assert PYPI_PUBLISH_ACTION_IMAGE in validation
+    assert "id-token: write" not in validation
 
 
 def test_publish_requires_current_canonical_main_head_equality() -> None:


### PR DESCRIPTION
Root cause:
The v0.8.0 publishing workflow pinned the v1.14.2 annotated-tag object SHA
instead of the dereferenced release commit SHA.

Repair:
- pin the exact upstream release commit
- add annotated-tag dereference regression coverage
- add exact GHCR runtime-image preflight
- prepare patch version 0.8.1

Scientific/runtime semantics:
No intentional change.