### PR TITLE
release: prepare 0.8.2 public truth synchronization

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      VERIREPRO_RELEASE_VERSION: 0.8.1
+      VERIREPRO_RELEASE_VERSION: 0.8.2
       VERIREPRO_SOURCE_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable user-facing changes are recorded here. Internal CI incidents and one-off maintainer infrastructure details are intentionally omitted from public release notes.
 
+## 0.8.2 — public release truth and metadata correction
+
+- synchronize public release-status documentation;
+- make PyPI installation the primary user path;
+- correct stale PyPI-facing README metadata through a new immutable package version;
+- refresh current release evidence after fresh source-bound certification;
+- no intentional scientific runtime or public API semantics change.
+
 ## 0.8.1 — release-delivery correction
 
 - correct the PyPI Trusted Publishing action pin so the v1.14.2 annotated
@@ -15,6 +23,9 @@ Notable user-facing changes are recorded here. Internal CI incidents and one-off
 - the v0.8.0 GitHub release completed, but its first PyPI delivery did not
   upload distributions because the publishing action used an annotated tag
   object SHA without a corresponding runtime image.
+- production PyPI Trusted Publishing subsequently completed successfully
+  through the protected GitHub environment;
+- clean installation from pypi.org was independently verified.
 
 ## 0.8.0 — hardened runtime, verification, and release engineering
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "VeriRepro: Evidence-grounded computational paper reproduction"
 type: software
 authors:
   - name: "VeriRepro contributors"
-version: 0.8.1
+version: 0.8.2
 license: Apache-2.0
 repository-code: "https://github.com/XiantingWu/VeriRepro"
 url: "https://github.com/XiantingWu/VeriRepro"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give VeriRepro an arXiv paper, DOI, PDF URL, or local PDF. It builds an inspecta
 
 VeriRepro is designed for the gap between “the code ran” and “the scientific result was actually reproduced.” Unsupported model output is never promoted into scientific evidence, repository-authored expected values do not self-certify a paper, and a successful process exit does not automatically become a scientific `PASS`.
 
-**Status:** `0.8.0` public-beta release candidate. The source tree and release evidence are certified, but the stable GitHub Release/PyPI publication is intentionally the final launch step. Until then, install from this repository as shown below. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
+**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. The current published production release is `0.8.1`; this repository is preparing the immutable `0.8.2` public truth-synchronization release. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
 
 ## Why VeriRepro
 
@@ -24,16 +24,20 @@ VeriRepro is designed for the gap between “the code ran” and “the scientif
 
 ## Quick start
 
-Start with a pinned paper from VeriRepro's fixed public smoke corpus. This path plans the reproduction without executing third-party experiment code or requiring a model endpoint:
+Install the published package from PyPI, then start with a pinned paper from VeriRepro's fixed public smoke corpus. This path plans the reproduction without executing third-party experiment code or requiring a model endpoint:
 
 ```bash
-git clone https://github.com/XiantingWu/VeriRepro.git
-cd VeriRepro
-python -m pip install .
+python -m pip install verirepro
 
 verirepro doctor --json
 verirepro plan 2103.00020v1
 verirepro reproduce 2103.00020v1 --no-execute --no-llm
+```
+
+To install the exact release prepared by this repository, use:
+
+```bash
+python -m pip install "verirepro==0.8.2"
 ```
 
 Before allowing third-party experiment code to execute, run:
@@ -85,19 +89,21 @@ PASS / FAIL / PARTIAL + evidence bundle
 
 ## Measured release evidence
 
-The `0.8.0` release-candidate source is currently certified on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The current Xianting-native authority is the exact-main validation run and its explicit evidence-only promotion recorded below; earlier source, fingerprint, and run records are historical and superseded (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
+The latest completed Xianting-native authority is the released `v0.8.1` source, certified on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The `0.8.2` candidate is not yet certified; its fresh authority will be recorded only after exact-main validation (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
 
 | Gate | Current measured result |
 | --- | --- |
 | Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
-| Tests / coverage | 782 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
-| Current release-source commit | `ace6683ff24399ff374eec5c05669b67783ffec9` |
-| Current release-source SHA-256 | `4cc5f2d80af9f08a5720cfce273c0f0fe8f2e21af586fffad98f5c939af1b4b8` |
-| Current exact-main validation run | GitHub-hosted `VeriRepro validation` run `33282504163` |
+| Tests / coverage | 803 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
+| Latest certified release-source commit (v0.8.1) | `0a0385ab655e4c58a3db527287dc888dacd14f94` |
+| Latest certified release-source SHA-256 (F3) | `45355990bec900d1efa2faf782eb3099d40927a7a65adf84291c1037a9627613` |
+| Latest exact-main validation run | GitHub-hosted `VeriRepro validation` run `33324289201` |
 | Real-paper discovery | 15/15 (found, top-1, evidence anchored) |
 | Environment planning | 3/3 bounded repository plans |
 | ReproBench | 1 success / 1 partial / 0 failures |
-| Current evidence commit | `820898feec6fc4f663c45bf0a42216c64d434bee` (evidence-only promotion, direct parent current certified source) |
+| Latest evidence commit (E3) | `68d50603e8a30b87bcb333cc510a3f85ea6926ce` (evidence-only promotion, direct parent certified source) |
+| v0.8.1 production PyPI publication | SUCCESS; publish run `33325816551` |
+| 0.8.2 certification authority | NOT YET CERTIFIED |
 | Certification environment | exact committed dependency snapshot; resolved on GitHub-hosted `ubuntu-latest` |
 
 All CI and validation runs execute on GitHub-hosted ephemeral runners; logs are safe by design and are retained as public quality evidence. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.
@@ -222,6 +228,14 @@ print(report.status)
 
 ## Development and contribution model
 
+For contributor installation from a checkout:
+
+```bash
+git clone https://github.com/XiantingWu/VeriRepro.git
+cd VeriRepro
+python -m pip install -e '.[dev]'
+```
+
 Local development checks:
 
 ```bash
@@ -254,23 +268,56 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before sending a change. For reproductio
 
 ## Documentation
 
+### Getting Started
+
 - [Getting started](docs/GETTING_STARTED.md)
-- [Canonical identity](docs/CANONICAL_IDENTITY.md)
-- [Release evidence](docs/EVIDENCE.md)
+
+### Architecture
+
 - [Architecture](docs/ARCHITECTURE.md)
+
+### Trust / Security
+
 - [Trust model](docs/TRUST_MODEL.md)
+- [Security policy](SECURITY.md)
+
+### Environment / GPU
+
+- [Environment](docs/ENVIRONMENT.md)
+- [Environment managers](docs/ENVIRONMENT_MANAGERS.md)
+- [GPU](docs/GPU.md)
+
+### Datasets / Models
+
 - [Real-paper smoke](docs/REAL_PAPER_SMOKE.md)
-- [ReproBench](docs/REPROBENCH.md)
 - [Datasets](docs/DATASETS.md)
 - [Model artifacts](docs/MODEL_ARTIFACTS.md)
 - [Outputs](docs/OUTPUTS.md)
 - [LiteLLM](docs/LITELLM.md)
-- [Schemas](docs/SCHEMAS.md)
+
+### ReproBench
+
+- [ReproBench](docs/REPROBENCH.md)
+
+### Evidence
+
+- [Canonical identity](docs/CANONICAL_IDENTITY.md)
+- [Release evidence](docs/EVIDENCE.md)
+
+### Publishing / Signing
+
 - [Publishing](docs/PUBLISHING.md)
+- [Release signing](docs/RELEASE_SIGNING.md)
+
+### Schemas
+
+- [Schemas](docs/SCHEMAS.md)
+
+### Support / Contribution
+
 - [Roadmap](ROADMAP.md)
 - [Contributing](CONTRIBUTING.md)
 - [Support](SUPPORT.md)
-- [Security](SECURITY.md)
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,11 @@
 
 VeriRepro is developed against measurable reproducibility, safety, and release gates rather than feature count. Roadmap items are phrased as observable capabilities so contributors can attach tests and evidence to them.
 
-## Current public-beta candidate — 0.8
+## Current public-beta line — 0.8
+
+The 0.8 line has reached public GitHub and PyPI distribution. Future entries
+describe planned capabilities and are not release commitments until their
+evidence and delivery gates are complete.
 
 The 0.8 line establishes the first public release baseline.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-VeriRepro is pre-1.0. Security fixes target the latest published 0.x release and current `main`; older 0.x lines are not maintained unless explicitly stated. Until `0.8.0` is published, reports should be evaluated against the current 0.8.0 release candidate / `main`.
+VeriRepro is pre-1.0. Security fixes target the latest published 0.x release and current `main`; older 0.x releases are not maintained unless explicitly stated.
 
 Do not place API keys, private paper contents, private repository URLs, unpublished datasets, or credentials in public issues or logs.
 

--- a/docs/CANONICAL_IDENTITY.md
+++ b/docs/CANONICAL_IDENTITY.md
@@ -15,6 +15,6 @@ For release and security decisions, verify all of the following together:
 - release evidence passes `scripts/release_check.py --require-release-evidence`;
 - release-source identity passes `scripts/release_source_check.py`;
 - all GitHub Actions workflows execute on GitHub-hosted runners only;
-- stable PyPI publication, when enabled, uses the `verirepro` project and the repository's protected Trusted Publishing path.
+- stable PyPI publication uses the `verirepro` project and the repository's protected Trusted Publishing path.
 
 A source-compatible copy can reproduce the code bytes while still being a different distribution authority. GitHub stars, repository names, or copied README text are not authority signals.

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -1,6 +1,6 @@
 # Release evidence
 
-This page is the human-readable index for VeriRepro `0.8.1` evidence. It records what was actually measured, which source identity produced the measurements, and what the measurements do **not** prove.
+This page is the human-readable index for VeriRepro `0.8` evidence. It records what was actually measured, which source identity produced the measurements, and what the measurements do **not** prove. The latest completed authority is the released v0.8.1 chain; the active v0.8.2 candidate is not yet certified.
 
 ## Evidence policy
 
@@ -69,10 +69,10 @@ evidence-only PR. S2/F2, validation run `33316585656`, and E2 are the
 historical v0.8.0 authority; the v0.8.0 PyPI delivery itself was not
 completed, and v0.8.0 was never published to PyPI.
 
-## Current Xianting-native certification (v0.8.1 candidate)
+## Released v0.8.1 certification authority
 
-The current v0.8.1 candidate authority was produced after the PyPI publisher
-delivery repair and is the only current certification authority:
+The released v0.8.1 authority was produced after the PyPI publisher delivery
+repair and is the latest completed certification authority:
 
 - Certified source (S3): `0a0385ab655e4c58a3db527287dc888dacd14f94`
 - Release-source SHA-256 (F3): `45355990bec900d1efa2faf782eb3099d40927a7a65adf84291c1037a9627613`
@@ -85,11 +85,30 @@ delivery repair and is the only current certification authority:
 - ReproBench: 1 success / 1 partial / 0 failures
 - Exact PyPI publisher runtime image preflight: PASS
   (`ghcr.io/pypa/gh-action-pypi-publish:dc37677b2e1c63e2034f94d8a5b11f265b73ba33`)
+- GitHub Release `v0.8.1`: PUBLISHED
+- PyPI `verirepro==0.8.1`: PUBLISHED
+- Publish run `33325816551`: SUCCESS through protected Trusted Publishing
+- Fresh clean PyPI install: PASS
 
 The validation run tested the exact S3 source and recorded F3 in the sanitized
 artifact. The artifact was reviewed and promoted through an explicit
-evidence-only PR. S3/F3, validation run `33324289201`, and E3 are current;
+evidence-only PR. S3/F3, validation run `33324289201`, and E3 are the latest
+completed authority;
 S2/F2, validation run `33316585656`, and E2 are historical v0.8.0 authority.
+
+## Active v0.8.2 candidate authority
+
+The 0.8.2 candidate exists to synchronize public release truth and correct
+PyPI-facing metadata through a new immutable package version. It has not yet
+completed fresh source-bound certification:
+
+- Certification status: **NOT YET CERTIFIED**
+- S4, F4, Validation4, and E4: not yet assigned
+- PyPI `verirepro==0.8.2`: not yet published
+
+No v0.8.1 evidence is reused as v0.8.2 evidence. The 0.8.2 authority will be
+promoted only from a sanitized Validation4 artifact after the exact canonical
+main source is frozen.
 
 ## Scientific limits
 

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
-# Public Release Checklist (0.8.1)
+# Public Release Checklist (0.8.2)
 
-Status: **pre-release engineering freeze complete; v0.8.1 publication remains separately unauthorized.**
+Status: **v0.8.1 production release complete; v0.8.2 preparation is active and is not yet certified or published.**
 
 ## Runner architecture
 
@@ -41,7 +41,7 @@ Status: **pre-release engineering freeze complete; v0.8.1 publication remains se
 - [x] publish re-runs release/launch/history/source/evidence gates before building
 - [x] release signer policy public key is provisioned; no stable tag may be created before the policy is verified
 - [x] v1.14.2 PyPI publisher action is pinned to its dereferenced release commit; the annotated tag-object SHA is not used
-- [x] exact PyPI publisher runtime-image manifest preflight passes for the 0.8.1 candidate
+- [x] exact PyPI publisher runtime-image manifest preflight passes for the v0.8.1 release
 
 ## Release signer
 
@@ -78,13 +78,16 @@ Status: **pre-release engineering freeze complete; v0.8.1 publication remains se
 - [x] S1 `ace6683ff24399ff374eec5c05669b67783ffec9`, F1 `4cc5f2d80af9f08a5720cfce273c0f0fe8f2e21af586fffad98f5c939af1b4b8`, old validation, and E1 are labelled historical
 - [x] `docs/EVIDENCE.md` distinguishes historical from current evidence and records scientific limits
 
-## Active v0.8.1 candidate
+## Released v0.8.1 authority
 
 - [x] source-hardening main `S3` frozen after the repair PR: `0a0385ab655e4c58a3db527287dc888dacd14f94`
 - [x] release-source fingerprint `F3` computed and different from historical F2: `45355990bec900d1efa2faf782eb3099d40927a7a65adf84291c1037a9627613`
 - [x] fresh certification (`Validation3`) completed on exact `S3`: run `33324289201`
 - [x] fresh evidence (`E3`) sanitized and promoted by an evidence-only PR: `68d50603e8a30b87bcb333cc510a3f85ea6926ce`
 - [x] `docs/EVIDENCE.md` updated with S3/F3/Validation3/E3 authority
+- [x] v0.8.1 signed annotated tag and GitHub Release published
+- [x] v0.8.1 PyPI Trusted Publishing completed successfully (run `33325816551`)
+- [x] fresh clean PyPI install verified
 
 ## Final quality target
 
@@ -103,9 +106,13 @@ Status: **pre-release engineering freeze complete; v0.8.1 publication remains se
 - [x] GitHub Release `v0.8.0` preserved as published non-prerelease
 - [x] PyPI `verirepro==0.8.0` was not published; no upload was attempted after the deterministic publisher-image failure
 
-## Deferred 0.8.1 publication
+## Active v0.8.2 release preparation
 
-- [ ] signed annotated tag `v0.8.1`
-- [ ] GitHub Release `v0.8.1`
-- [ ] PyPI Trusted Publishing publication
+- [ ] fresh exact-main certification (`Validation4`) and sanitized evidence (`E4`)
+- [ ] signed annotated tag `v0.8.2`
+- [ ] GitHub Release `v0.8.2`
+- [ ] PyPI Trusted Publishing publication for `verirepro==0.8.2`
+
+## Deferred cross-account smoke
+
 - [ ] live fork PR smoke on a second account (static contract PASS; deferred pending an independent authorized public fork identity)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "verirepro"
-version = "0.8.1"
+version = "0.8.2"
 description = "Evidence-grounded agent for verifiable computational paper reproduction"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/reproagent/__init__.py
+++ b/src/reproagent/__init__.py
@@ -9,4 +9,4 @@ from .core import ReproductionPlan, build_reproduction_plan
 from .pipeline import reproduce
 
 __all__ = ["ReproductionPlan", "build_reproduction_plan", "reproduce"]
-__version__ = "0.8.1"
+__version__ = "0.8.2"


### PR DESCRIPTION
## Summary

- fixes stale post-release public status and PyPI-facing documentation;
- bumps to 0.8.2 because the published PyPI 0.8.1 distribution is immutable;
- does not rewrite v0.8.0 or v0.8.1 tags, releases, or distributions;
- does not intentionally change scientific, runtime, or public API behavior;
- fresh 0.8.2 evidence will be generated only after merge.

## Validation

- local Ruff, format, mypy, 803-test, history, launch-surface, and source checks completed;
- release-source evidence check remains fail-closed until fresh 0.8.2 evidence exists.