### PR TITLE
docs: record 0.8.2 certification authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give VeriRepro an arXiv paper, DOI, PDF URL, or local PDF. It builds an inspecta
 
 VeriRepro is designed for the gap between “the code ran” and “the scientific result was actually reproduced.” Unsupported model output is never promoted into scientific evidence, repository-authored expected values do not self-certify a paper, and a successful process exit does not automatically become a scientific `PASS`.
 
-**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. The current published production release is `0.8.1`; this repository is preparing the immutable `0.8.2` public truth-synchronization release. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
+**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. The current published production release is `0.8.1`; the immutable `0.8.2` candidate has completed source-bound certification and is awaiting its signed tag, GitHub Release, and PyPI delivery. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
 
 ## Why VeriRepro
 
@@ -89,21 +89,21 @@ PASS / FAIL / PARTIAL + evidence bundle
 
 ## Measured release evidence
 
-The latest completed Xianting-native authority is the released `v0.8.1` source, certified on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The `0.8.2` candidate is not yet certified; its fresh authority will be recorded only after exact-main validation (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
+The latest completed Xianting-native authority is the `v0.8.2` certified candidate, measured on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The candidate is source-bound to exact canonical `main`; its release delivery remains a separate signed-tag and PyPI step (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
 
 | Gate | Current measured result |
 | --- | --- |
 | Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
 | Tests / coverage | 803 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
-| Latest certified release-source commit (v0.8.1) | `0a0385ab655e4c58a3db527287dc888dacd14f94` |
-| Latest certified release-source SHA-256 (F3) | `45355990bec900d1efa2faf782eb3099d40927a7a65adf84291c1037a9627613` |
-| Latest exact-main validation run | GitHub-hosted `VeriRepro validation` run `33324289201` |
+| Certified candidate release-source commit (S4) | `96fc9305c07ecacaa9d13c3e159c4650575d2339` |
+| Certified candidate release-source SHA-256 (F4) | `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324` |
+| Exact-main validation run (Validation4) | GitHub-hosted `VeriRepro validation` run `33333603696` |
 | Real-paper discovery | 15/15 (found, top-1, evidence anchored) |
 | Environment planning | 3/3 bounded repository plans |
 | ReproBench | 1 success / 1 partial / 0 failures |
-| Latest evidence commit (E3) | `68d50603e8a30b87bcb333cc510a3f85ea6926ce` (evidence-only promotion, direct parent certified source) |
+| Candidate evidence commit (E4) | `028bb7e98b1985f647e46e2e4e349a23ff78bb6b` (evidence-only promotion, direct parent certified source) |
 | v0.8.1 production PyPI publication | SUCCESS; publish run `33325816551` |
-| 0.8.2 certification authority | NOT YET CERTIFIED |
+| v0.8.2 certification authority | CERTIFIED CANDIDATE; release delivery pending |
 | Certification environment | exact committed dependency snapshot; resolved on GitHub-hosted `ubuntu-latest` |
 
 All CI and validation runs execute on GitHub-hosted ephemeral runners; logs are safe by design and are retained as public quality evidence. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -1,6 +1,6 @@
 # Release evidence
 
-This page is the human-readable index for VeriRepro `0.8` evidence. It records what was actually measured, which source identity produced the measurements, and what the measurements do **not** prove. The latest completed authority is the released v0.8.1 chain; the active v0.8.2 candidate is not yet certified.
+This page is the human-readable index for VeriRepro `0.8` evidence. It records what was actually measured, which source identity produced the measurements, and what the measurements do **not** prove. The latest completed certification authority is the v0.8.2 candidate; the latest completed production publication is v0.8.1.
 
 ## Evidence policy
 
@@ -72,7 +72,7 @@ completed, and v0.8.0 was never published to PyPI.
 ## Released v0.8.1 certification authority
 
 The released v0.8.1 authority was produced after the PyPI publisher delivery
-repair and is the latest completed certification authority:
+repair and remains the production evidence authority for that release:
 
 - Certified source (S3): `0a0385ab655e4c58a3db527287dc888dacd14f94`
 - Release-source SHA-256 (F3): `45355990bec900d1efa2faf782eb3099d40927a7a65adf84291c1037a9627613`
@@ -96,19 +96,27 @@ evidence-only PR. S3/F3, validation run `33324289201`, and E3 are the latest
 completed authority;
 S2/F2, validation run `33316585656`, and E2 are historical v0.8.0 authority.
 
-## Active v0.8.2 candidate authority
+## Current v0.8.2 certified candidate authority
 
-The 0.8.2 candidate exists to synchronize public release truth and correct
-PyPI-facing metadata through a new immutable package version. It has not yet
-completed fresh source-bound certification:
+The 0.8.2 candidate synchronizes public release truth and corrects
+PyPI-facing metadata through a new immutable package version. Fresh
+source-bound certification completed on the exact canonical main source:
 
-- Certification status: **NOT YET CERTIFIED**
-- S4, F4, Validation4, and E4: not yet assigned
+- Certified source (S4): `96fc9305c07ecacaa9d13c3e159c4650575d2339`
+- Release-source SHA-256 (F4): `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324`
+- Validation run (Validation4): GitHub-hosted `VeriRepro validation` run `33333603696`
+- Evidence commit (E4): `028bb7e98b1985f647e46e2e4e349a23ff78bb6b`
+- Discovery: 15/15 expected repositories, 15/15 top-1, 15/15 evidence anchored
+- Planning: 3/3 expected repositories, 3/3 top-1, 3/3 evidence anchored
+- ReproBench: 1 success / 1 partial / 0 failures
+- Certification status: **CERTIFIED CANDIDATE**
+- GitHub Release `v0.8.2`: not yet published
 - PyPI `verirepro==0.8.2`: not yet published
 
-No v0.8.1 evidence is reused as v0.8.2 evidence. The 0.8.2 authority will be
-promoted only from a sanitized Validation4 artifact after the exact canonical
-main source is frozen.
+The evidence-only promotion was generated from the sanitized Validation4
+artifact after the exact canonical main source was frozen. No v0.8.1 evidence
+was reused as v0.8.2 evidence. Release delivery must still use the signed tag
+and protected PyPI Trusted Publishing path.
 
 ## Scientific limits
 

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Public Release Checklist (0.8.2)
 
-Status: **v0.8.1 production release complete; v0.8.2 preparation is active and is not yet certified or published.**
+Status: **v0.8.1 production release complete; v0.8.2 is a certified candidate awaiting signed-tag, GitHub Release, and PyPI delivery.**
 
 ## Runner architecture
 
@@ -106,9 +106,17 @@ Status: **v0.8.1 production release complete; v0.8.2 preparation is active and i
 - [x] GitHub Release `v0.8.0` preserved as published non-prerelease
 - [x] PyPI `verirepro==0.8.0` was not published; no upload was attempted after the deterministic publisher-image failure
 
-## Active v0.8.2 release preparation
+## Current v0.8.2 certified candidate
 
-- [ ] fresh exact-main certification (`Validation4`) and sanitized evidence (`E4`)
+- [x] fresh exact-main certification (`Validation4`) on `S4`: run `33333603696`
+- [x] release-source fingerprint `F4`: `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324`
+- [x] sanitized evidence promoted as `E4`: `028bb7e98b1985f647e46e2e4e349a23ff78bb6b`
+- [x] 803 tests with 86.4% statement coverage and 79.9% branch coverage
+- [x] discovery 15/15 and bounded planning 3/3
+- [x] ReproBench gate: 1 success / 1 partial / 0 failures
+
+## Pending v0.8.2 delivery
+
 - [ ] signed annotated tag `v0.8.2`
 - [ ] GitHub Release `v0.8.2`
 - [ ] PyPI Trusted Publishing publication for `verirepro==0.8.2`


### PR DESCRIPTION
## Summary

- records S4 `96fc9305c07ecacaa9d13c3e159c4650575d2339`;
- records F4 `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324`;
- records Validation4 run `33333603696`;
- records evidence merge E4 `028bb7e98b1985f647e46e2e4e349a23ff78bb6b`;
- marks `0.8.2` as CERTIFIED CANDIDATE while keeping GitHub Release and PyPI publication pending;
- docs-only: no release-source bytes are changed.