### PR TITLE
docs: close 0.8.2 public release truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give VeriRepro an arXiv paper, DOI, PDF URL, or local PDF. It builds an inspecta
 
 VeriRepro is designed for the gap between “the code ran” and “the scientific result was actually reproduced.” Unsupported model output is never promoted into scientific evidence, repository-authored expected values do not self-certify a paper, and a successful process exit does not automatically become a scientific `PASS`.
 
-**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. The current published production release is `0.8.1`; the immutable `0.8.2` candidate has completed source-bound certification and is awaiting its signed tag, GitHub Release, and PyPI delivery. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
+**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. The current published production release is `0.8.2`, certified from an immutable source-bound release chain. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
 
 ## Why VeriRepro
 
@@ -89,21 +89,22 @@ PASS / FAIL / PARTIAL + evidence bundle
 
 ## Measured release evidence
 
-The latest completed Xianting-native authority is the `v0.8.2` certified candidate, measured on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The candidate is source-bound to exact canonical `main`; its release delivery remains a separate signed-tag and PyPI step (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
+The current Xianting-native authority is the released `v0.8.2` source, measured on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The release is source-bound to exact canonical `main` and its signed tag (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
 
 | Gate | Current measured result |
 | --- | --- |
 | Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
 | Tests / coverage | 803 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
-| Certified candidate release-source commit (S4) | `96fc9305c07ecacaa9d13c3e159c4650575d2339` |
-| Certified candidate release-source SHA-256 (F4) | `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324` |
+| Released source commit (S4) | `96fc9305c07ecacaa9d13c3e159c4650575d2339` |
+| Released source SHA-256 (F4) | `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324` |
 | Exact-main validation run (Validation4) | GitHub-hosted `VeriRepro validation` run `33333603696` |
 | Real-paper discovery | 15/15 (found, top-1, evidence anchored) |
 | Environment planning | 3/3 bounded repository plans |
 | ReproBench | 1 success / 1 partial / 0 failures |
-| Candidate evidence commit (E4) | `028bb7e98b1985f647e46e2e4e349a23ff78bb6b` (evidence-only promotion, direct parent certified source) |
-| v0.8.1 production PyPI publication | SUCCESS; publish run `33325816551` |
-| v0.8.2 certification authority | CERTIFIED CANDIDATE; release delivery pending |
+| Released evidence commit (E4) | `028bb7e98b1985f647e46e2e4e349a23ff78bb6b` (evidence-only promotion, direct parent certified source) |
+| v0.8.2 GitHub Release | PUBLISHED |
+| v0.8.2 production PyPI publication | SUCCESS; publish run `33334230170` |
+| v0.8.2 certification authority | CERTIFIED and PUBLISHED |
 | Certification environment | exact committed dependency snapshot; resolved on GitHub-hosted `ubuntu-latest` |
 
 All CI and validation runs execute on GitHub-hosted ephemeral runners; logs are safe by design and are retained as public quality evidence. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -1,6 +1,6 @@
 # Release evidence
 
-This page is the human-readable index for VeriRepro `0.8` evidence. It records what was actually measured, which source identity produced the measurements, and what the measurements do **not** prove. The latest completed certification authority is the v0.8.2 candidate; the latest completed production publication is v0.8.1.
+This page is the human-readable index for VeriRepro `0.8` evidence. It records what was actually measured, which source identity produced the measurements, and what the measurements do **not** prove. The latest completed certification and production authority is released v0.8.2; v0.8.1 remains the previous production release authority.
 
 ## Evidence policy
 
@@ -96,11 +96,11 @@ evidence-only PR. S3/F3, validation run `33324289201`, and E3 are the latest
 completed authority;
 S2/F2, validation run `33316585656`, and E2 are historical v0.8.0 authority.
 
-## Current v0.8.2 certified candidate authority
+## Released v0.8.2 certification authority
 
-The 0.8.2 candidate synchronizes public release truth and corrects
-PyPI-facing metadata through a new immutable package version. Fresh
-source-bound certification completed on the exact canonical main source:
+The 0.8.2 release synchronizes public release truth and corrects PyPI-facing
+metadata through a new immutable package version. Fresh source-bound
+certification completed on the exact canonical main source:
 
 - Certified source (S4): `96fc9305c07ecacaa9d13c3e159c4650575d2339`
 - Release-source SHA-256 (F4): `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324`
@@ -109,14 +109,16 @@ source-bound certification completed on the exact canonical main source:
 - Discovery: 15/15 expected repositories, 15/15 top-1, 15/15 evidence anchored
 - Planning: 3/3 expected repositories, 3/3 top-1, 3/3 evidence anchored
 - ReproBench: 1 success / 1 partial / 0 failures
-- Certification status: **CERTIFIED CANDIDATE**
-- GitHub Release `v0.8.2`: not yet published
-- PyPI `verirepro==0.8.2`: not yet published
+- Certification status: **CERTIFIED and PUBLISHED**
+- GitHub Release `v0.8.2`: PUBLISHED
+- PyPI `verirepro==0.8.2`: PUBLISHED
+- Publish run `33334230170`: SUCCESS through protected Trusted Publishing
+- Fresh clean PyPI install: PASS
 
 The evidence-only promotion was generated from the sanitized Validation4
 artifact after the exact canonical main source was frozen. No v0.8.1 evidence
-was reused as v0.8.2 evidence. Release delivery must still use the signed tag
-and protected PyPI Trusted Publishing path.
+was reused as v0.8.2 evidence. Release delivery used the signed tag and
+protected PyPI Trusted Publishing path.
 
 ## Scientific limits
 

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Public Release Checklist (0.8.2)
 
-Status: **v0.8.1 production release complete; v0.8.2 is a certified candidate awaiting signed-tag, GitHub Release, and PyPI delivery.**
+Status: **v0.8.2 production release complete; signed tag, GitHub Release, and PyPI publication are verified.**
 
 ## Runner architecture
 
@@ -106,7 +106,7 @@ Status: **v0.8.1 production release complete; v0.8.2 is a certified candidate aw
 - [x] GitHub Release `v0.8.0` preserved as published non-prerelease
 - [x] PyPI `verirepro==0.8.0` was not published; no upload was attempted after the deterministic publisher-image failure
 
-## Current v0.8.2 certified candidate
+## Released v0.8.2 authority
 
 - [x] fresh exact-main certification (`Validation4`) on `S4`: run `33333603696`
 - [x] release-source fingerprint `F4`: `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324`
@@ -114,12 +114,16 @@ Status: **v0.8.1 production release complete; v0.8.2 is a certified candidate aw
 - [x] 803 tests with 86.4% statement coverage and 79.9% branch coverage
 - [x] discovery 15/15 and bounded planning 3/3
 - [x] ReproBench gate: 1 success / 1 partial / 0 failures
+- [x] signed annotated tag `v0.8.2` verified and pushed without force
+- [x] GitHub Release `v0.8.2` published
+- [x] PyPI Trusted Publishing succeeded in run `33334230170`
+- [x] fresh clean PyPI install verified
 
-## Pending v0.8.2 delivery
+## Completed v0.8.2 delivery
 
-- [ ] signed annotated tag `v0.8.2`
-- [ ] GitHub Release `v0.8.2`
-- [ ] PyPI Trusted Publishing publication for `verirepro==0.8.2`
+- [x] signed annotated tag `v0.8.2`
+- [x] GitHub Release `v0.8.2`
+- [x] PyPI Trusted Publishing publication for `verirepro==0.8.2`
 
 ## Deferred cross-account smoke
 


### PR DESCRIPTION
## Summary

- records v0.8.2 GitHub Release as PUBLISHED;
- records PyPI `verirepro==0.8.2` as PUBLISHED;
- records Publish run `33334230170` and Trusted Publishing SUCCESS;
- records clean PyPI install PASS;
- docs-only: preserves the F4-covered source tree.