### PR TITLE
release: prepare 0.8.3 metadata finalization

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      VERIREPRO_RELEASE_VERSION: 0.8.2
+      VERIREPRO_RELEASE_VERSION: 0.8.3
       VERIREPRO_SOURCE_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable user-facing changes are recorded here. Internal CI incidents and one-off maintainer infrastructure details are intentionally omitted from public release notes.
 
+## 0.8.3 — metadata finalization and current-main certification
+
+- replace version-sensitive PyPI long-description status wording with release-stable wording;
+- supersede the stale long-description wording embedded in PyPI 0.8.2 without modifying that historical distribution;
+- include the already-merged repository-maintenance hardening present on current main;
+- no intentional scientific reproduction semantics change unless the release diff proves otherwise;
+- receive fresh source-bound validation and evidence before publication.
+
 ## 0.8.2 — public release truth and metadata correction
 
 - synchronize public release-status documentation;

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "VeriRepro: Evidence-grounded computational paper reproduction"
 type: software
 authors:
   - name: "VeriRepro contributors"
-version: 0.8.2
+version: 0.8.3
 license: Apache-2.0
 repository-code: "https://github.com/XiantingWu/VeriRepro"
 url: "https://github.com/XiantingWu/VeriRepro"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Give VeriRepro an arXiv paper, DOI, PDF URL, or local PDF. It builds an inspecta
 
 VeriRepro is designed for the gap between “the code ran” and “the scientific result was actually reproduced.” Unsupported model output is never promoted into scientific evidence, repository-authored expected values do not self-certify a paper, and a successful process exit does not automatically become a scientific `PASS`.
 
-**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. The current published production release is `0.8.2`, certified from an immutable source-bound release chain. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
+**Status:** VeriRepro is a public-beta Python package distributed through PyPI and released from the canonical [XiantingWu/VeriRepro](https://github.com/XiantingWu/VeriRepro) repository. `python -m pip install verirepro` installs the current published package. Version-specific certification and release authorities are recorded in [docs/EVIDENCE.md](docs/EVIDENCE.md) and GitHub Releases, not in this package description. The preferred package, CLI, and Python namespace are `verirepro`; the legacy `reproagent` CLI/import remain compatibility aliases during the 0.x series. The authoritative repository/package identity is defined in [docs/CANONICAL_IDENTITY.md](docs/CANONICAL_IDENTITY.md); similarly named copies are not release authorities by name alone.
 
 ## Why VeriRepro
 
@@ -34,11 +34,13 @@ verirepro plan 2103.00020v1
 verirepro reproduce 2103.00020v1 --no-execute --no-llm
 ```
 
-To install the exact release prepared by this repository, use:
+To install a deterministic version pin instead, use a version-neutral form:
 
 ```bash
-python -m pip install "verirepro==0.8.2"
+python -m pip install "verirepro==<version>"
 ```
+
+Specific release pins are recorded in each GitHub Release's notes; the PyPI metadata of a released version is immutable and never changes after publication.
 
 Before allowing third-party experiment code to execute, run:
 
@@ -87,27 +89,19 @@ metrics + Figure/Table/file evidence
 PASS / FAIL / PARTIAL + evidence bundle
 ```
 
-## Measured release evidence
+## Release certification evidence
 
-The current Xianting-native authority is the released `v0.8.2` source, measured on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. The release is source-bound to exact canonical `main` and its signed tag (see [docs/EVIDENCE.md](docs/EVIDENCE.md)).
+Certification is measured on **GitHub-hosted runners only**. This public repository never uses maintainer-owned self-hosted runners, private runner labels, or runner groups for CI, validation, certification, or publishing. Releases are source-bound to the exact canonical `main` source and its signed annotated tag; no private certification chain is ever claimed as this repository's own.
 
-| Gate | Current measured result |
+| Mechanism | Policy |
 | --- | --- |
-| Public CI/validation runner | GitHub-hosted (`ubuntu-latest`) |
-| Tests / coverage | 803 tests; 86.4% statement / 79.9% branch on the 3.11 lane |
-| Released source commit (S4) | `96fc9305c07ecacaa9d13c3e159c4650575d2339` |
-| Released source SHA-256 (F4) | `95904277df77db6e97e83cafe57a351a100c4b3084453c7083edf6cd0baeb324` |
-| Exact-main validation run (Validation4) | GitHub-hosted `VeriRepro validation` run `33333603696` |
-| Real-paper discovery | 15/15 (found, top-1, evidence anchored) |
-| Environment planning | 3/3 bounded repository plans |
-| ReproBench | 1 success / 1 partial / 0 failures |
-| Released evidence commit (E4) | `028bb7e98b1985f647e46e2e4e349a23ff78bb6b` (evidence-only promotion, direct parent certified source) |
-| v0.8.2 GitHub Release | PUBLISHED |
-| v0.8.2 production PyPI publication | SUCCESS; publish run `33334230170` |
-| v0.8.2 certification authority | CERTIFIED and PUBLISHED |
-| Certification environment | exact committed dependency snapshot; resolved on GitHub-hosted `ubuntu-latest` |
+| CI / validation / certification runners | GitHub-hosted (`ubuntu-latest`) only |
+| Certification path | exact canonical `main` → fresh validation → sanitized artifact → explicit evidence-only promotion |
+| Release-source fingerprint | SHA-256 over release-relevant sources (`scripts/release_source_check.py`) |
+| Publisher delivery | protected `pypi` environment; OIDC Trusted Publishing only |
+| Evidence records | [docs/EVIDENCE.md](docs/EVIDENCE.md) and the matching GitHub Release |
 
-All CI and validation runs execute on GitHub-hosted ephemeral runners; logs are safe by design and are retained as public quality evidence. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.
+The exact certified source identity, release-source fingerprint, validation run, and evidence commit for each release are recorded in [docs/EVIDENCE.md](docs/EVIDENCE.md) and the matching GitHub Release, rather than embedded as release-state prose in this package description. Run IDs inside sanitized evidence remain provenance-correlation fields. Public verification relies on the committed, SHA-256-bound files under `benchmarks/`, not on machine identity.
 
 These are bounded release measurements, not a claim that arbitrary papers are zero-config reproducible. The 15-paper gate measures discovery/evidence and bounded planning; it does not claim that all 15 papers were fully reproduced. The governance seed intentionally remains `PARTIAL` because no independent scientific comparison is authorized for it; successful process execution is not promoted into scientific truth. See [docs/EVIDENCE.md](docs/EVIDENCE.md) for provenance, scope, and limits.
 

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -120,6 +120,13 @@ artifact after the exact canonical main source was frozen. No v0.8.1 evidence
 was reused as v0.8.2 evidence. Release delivery used the signed tag and
 protected PyPI Trusted Publishing path.
 
+## v0.8.3 candidate certification
+
+**NOT YET CERTIFIED.** The v0.8.3 metadata-finalization patch is prepared on
+`main`; fresh source-bound certification, evidence, and production authority
+will be recorded here after the release-relevant source is frozen and the
+sanitized validation artifact is promoted.
+
 ## Scientific limits
 
 - A 15-paper discovery corpus, 3-repository environment planning, and 2-case ReproBench seed exercise certify only the tested gates and inputs.

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
-# Public Release Checklist (0.8.2)
+# Public Release Checklist (0.8.2 / 0.8.3)
 
-Status: **v0.8.2 production release complete; signed tag, GitHub Release, and PyPI publication are verified.**
+Status: **v0.8.2 production release complete; signed tag, GitHub Release, and PyPI publication are verified. v0.8.3 metadata finalization is in release preparation.**
 
 ## Runner architecture
 
@@ -41,7 +41,7 @@ Status: **v0.8.2 production release complete; signed tag, GitHub Release, and Py
 - [x] publish re-runs release/launch/history/source/evidence gates before building
 - [x] release signer policy public key is provisioned; no stable tag may be created before the policy is verified
 - [x] v1.14.2 PyPI publisher action is pinned to its dereferenced release commit; the annotated tag-object SHA is not used
-- [x] exact PyPI publisher runtime-image manifest preflight passes for the v0.8.1 release
+- [x] exact PyPI publisher runtime-image manifest preflight is part of the certified release-validation path
 
 ## Release signer
 
@@ -124,6 +124,21 @@ Status: **v0.8.2 production release complete; signed tag, GitHub Release, and Py
 - [x] signed annotated tag `v0.8.2`
 - [x] GitHub Release `v0.8.2`
 - [x] PyPI Trusted Publishing publication for `verirepro==0.8.2`
+
+## 0.8.3 release preparation (metadata finalization)
+
+- [ ] README/package-status wording made release-state-neutral and stable
+- [ ] version bumped to 0.8.3 on all authoritative surfaces
+- [ ] v0.8.3 release-relevant source frozen (S5) and fingerprint computed (F5)
+- [ ] fresh GitHub-hosted validation completed (Validation5)
+- [ ] v0.8.3 evidence promoted from the exact sanitized artifact (E5)
+- [ ] v0.8.3 certification authority recorded
+- [ ] signed annotated tag `v0.8.3` created and verified
+- [ ] GitHub Release `v0.8.3` published
+- [ ] PyPI Trusted Publishing publication for `verirepro==0.8.3`
+- [ ] fresh clean external PyPI install verified
+- [ ] PyPI live long-description release-stability verification
+- [ ] Immutable Release verification
 
 ## Deferred cross-account smoke
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "verirepro"
-version = "0.8.2"
+version = "0.8.3"
 description = "Evidence-grounded agent for verifiable computational paper reproduction"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/scripts/release_checks/package_surface.py
+++ b/scripts/release_checks/package_surface.py
@@ -9,6 +9,49 @@ from .common import BASE_REQUIRED_FILES, is_at_least, version_tuple
 
 CANONICAL_REPOSITORY = "https://github.com/XiantingWu/VeriRepro"
 EXPECTED_REQUIRES_PYTHON = ">=3.11,<3.14"
+
+README_RELEASE_STATE_SENSITIVE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"current published production release is", re.IGNORECASE),
+        "must not name a current published production release",
+    ),
+    (
+        re.compile(r"current production release is", re.IGNORECASE),
+        "must not name a current production release",
+    ),
+    (
+        re.compile(r"latest production release is", re.IGNORECASE),
+        "must not name a latest production release",
+    ),
+    (
+        re.compile(r"production release is\s+[`'\"v]*\d+\.\d+", re.IGNORECASE),
+        "must not embed a release-specific version in status prose",
+    ),
+    (
+        re.compile(r"current published version", re.IGNORECASE),
+        "must not embed a current published version",
+    ),
+    (
+        re.compile(r"\bcandidate\b", re.IGNORECASE),
+        "must not describe the package as a release candidate",
+    ),
+    (
+        re.compile(r"\bawaiting\s+PyPI\b", re.IGNORECASE),
+        "must not describe awaiting PyPI publication",
+    ),
+    (
+        re.compile(r"\bwaiting\s+for\s+PyPI\b", re.IGNORECASE),
+        "must not describe waiting for PyPI publication",
+    ),
+    (
+        re.compile(r"\bpublication\s+pending\b", re.IGNORECASE),
+        "must not describe pending publication",
+    ),
+    (
+        re.compile(r"install\s+from\s+repository\s+until\s+PyPI", re.IGNORECASE),
+        "must not direct repository installation until PyPI publication",
+    ),
+)
 EXPECTED_PROJECT_URLS = {
     "Homepage": CANONICAL_REPOSITORY,
     "Repository": CANONICAL_REPOSITORY,
@@ -216,3 +259,8 @@ def _check_public_documents(root: Path, version: str, errors: list[str]) -> None
         errors.append("README must clone the canonical standalone repository")
     if is_at_least(version, (0, 7, 0)) and "verirepro-reprobench" not in readme:
         errors.append("0.7+ README must document the ReproBench CLI")
+    for pattern, rationale in README_RELEASE_STATE_SENSITIVE_PATTERNS:
+        if pattern.search(readme):
+            errors.append(
+                f"README package-status wording must be release-state-neutral ({rationale})"
+            )

--- a/src/reproagent/__init__.py
+++ b/src/reproagent/__init__.py
@@ -9,4 +9,4 @@ from .core import ReproductionPlan, build_reproduction_plan
 from .pipeline import reproduce
 
 __all__ = ["ReproductionPlan", "build_reproduction_plan", "reproduce"]
-__version__ = "0.8.2"
+__version__ = "0.8.3"


### PR DESCRIPTION
## Summary

Release preparation for **v0.8.3** metadata finalization:

- PyPI `verirepro==0.8.2` is **preserved unchanged** as a historical immutable distribution.
- **0.8.3 supersedes only the stale immutable long-description wording** embedded in PyPI 0.8.2; that historical distribution is not modified, yanked, or re-uploaded.
- The README (the `pyproject.toml` long-description source copied into wheel/sdist/PyPI metadata) is now **release-state-neutral and time-stable**, so future releases (0.8.4+) no longer require README release-status rewrites.
- Detailed per-release certification authority (S/F/Validation/E) now lives in `docs/EVIDENCE.md` and GitHub Releases instead of the package description.
- Current hardened `main` will receive a **fresh source-bound certification** (new S5/F5/Validation5/E5) before publication.
- **No historical tag, release, evidence, or evidence value is rewritten or moved.**
- **No intentional scientific runtime semantics change**; only version surfaces, documentation truth, and release-policy wording.

## Changes

- Version bump `0.8.2 -> 0.8.3` on authoritative surfaces only: `pyproject.toml`, `src/reproagent/__init__.py`, `CITATION.cff`, `.github/workflows/validation.yml`.
- README: version-neutral status wording; version-neutral deterministic pin (`verirepro==<version>`); release-evidence section rewritten as mechanism-level policy with pointers to `docs/EVIDENCE.md` and GitHub Releases.
- `docs/EVIDENCE.md`: v0.8.2 authority preserved; new `v0.8.3 candidate certification` section marked `NOT YET CERTIFIED`.
- `docs/PUBLIC_RELEASE_CHECKLIST.md`: stale v0.8.1 publisher-preflight residue replaced with the stable certified-path expression; new unchecked `0.8.3 release preparation` section.
- `CHANGELOG.md`: new `0.8.3` entry (does not claim publication).
- `scripts/release_checks/package_surface.py`: automated contract gate forbidding release-state-sensitive README wording (regression guard for the metadata-drift root cause).

## Gates

- Quality (Python 3.11), Compatibility (Python 3.12/3.13), Dependency Review, CodeQL, and repository contract checks are expected on this PR.
- No ruleset bypass; no direct push to `main`; squash/rebase merge per `main-protection` ruleset.
